### PR TITLE
Fix | Remove duplicate titles in Discord embed

### DIFF
--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -10,7 +10,6 @@
     <meta name="theme-color" content="<%= meta[:theme_color] %>">
     <meta name="description" content="<%= meta[:description] %>">
     <meta property="og:type" content="website">
-    <meta property="og:title" content="<%= meta[:site_name] %>">
     <meta property="og:description" content="<%= meta[:description] %>">
     <meta property="og:image" content="<%= meta[:url] %><%= meta[:og_image] %>">
     <%= csrf_meta_tags %>


### PR DESCRIPTION
# Overview
Discord was showing "Griffith ICT Club" three times in link embeds — from og:title, og:site_name, and the page title tag.

# Summary of Changes
- Removed og:title and og:site_name meta tags, letting Discord use the page `<title>` as the single heading

# Testing / QA
- [x] Share a link in Discord and verify "Griffith ICT Club" only appears once as the blue clickable title
- [x] Verify description, theme color, and image still display correctly