### PR TITLE
Fix | Add back og:title for Discord embed

### DIFF
--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -10,6 +10,7 @@
     <meta name="theme-color" content="<%= meta[:theme_color] %>">
     <meta name="description" content="<%= meta[:description] %>">
     <meta property="og:type" content="website">
+    <meta property="og:title" content="<%= meta[:site_name] %>">
     <meta property="og:description" content="<%= meta[:description] %>">
     <meta property="og:image" content="<%= meta[:url] %><%= meta[:og_image] %>">
     <%= csrf_meta_tags %>


### PR DESCRIPTION
# Overview
Previous PR removed all OG title tags which left the Discord embed with no heading.

# Summary of Changes
- Added back `og:title` (without `og:site_name`) so Discord shows a single title heading

# Testing / QA
- [x] Share a link in Discord and verify one "Griffith ICT Club" title appears
- [x] Verify description, image, and red sidebar still display