### PR TITLE
Feature | Label-triggered PR preview deployments

### DIFF
--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -1,0 +1,189 @@
+name: Preview
+
+on:
+  pull_request:
+    types: [labeled, unlabeled, closed, synchronize]
+
+concurrency:
+  group: preview-pr-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+jobs:
+  deploy-preview:
+    if: >
+      (github.event.action == 'labeled' && github.event.label.name == 'preview') ||
+      (github.event.action == 'synchronize' && contains(github.event.pull_request.labels.*.name, 'preview'))
+    runs-on: ubuntu-latest
+    steps:
+      # Port allocation: 4000 + PR number. When this limit is hit, switch to
+      # Unix sockets — have Puma bind to /opt/previews/pr-{number}/tmp/puma.sock
+      # and proxy_pass to unix:/path/to/puma.sock in nginx. No port math, infinite previews.
+      - name: Check port range
+        run: |
+          PR_NUMBER=${{ github.event.pull_request.number }}
+          if [ "$PR_NUMBER" -gt 1000 ]; then
+            echo "::error::PR #${PR_NUMBER} exceeds port range for preview deployments (4000 + PR number). Re-engineer the port allocation strategy (see comment above)."
+            exit 1
+          fi
+
+      - name: Deploy preview
+        uses: nick-fields/retry@v3
+        env:
+          VPS_SSH_KEY: ${{ secrets.VPS_SSH_KEY }}
+          VPS_HOST: ${{ secrets.VPS_HOST }}
+        with:
+          timeout_minutes: 5
+          max_attempts: 3
+          retry_wait_seconds: 30
+          command: |
+            echo "$VPS_SSH_KEY" > /tmp/deploy_key
+            chmod 600 /tmp/deploy_key
+
+            PR_NUMBER=${{ github.event.pull_request.number }}
+            PR_BRANCH=${{ github.event.pull_request.head.ref }}
+            PR_REPO=${{ github.event.pull_request.head.repo.clone_url }}
+            PORT=$((4000 + PR_NUMBER))
+
+            ssh -o StrictHostKeyChecking=no -o ConnectTimeout=30 -i /tmp/deploy_key root@$VPS_HOST bash -s <<DEPLOY_SCRIPT
+              export PATH="\$HOME/.rbenv/bin:\$HOME/.rbenv/shims:\$PATH"
+              PREVIEW_DIR="/opt/previews/pr-${PR_NUMBER}"
+
+              # Clone or update
+              if [ -d "\$PREVIEW_DIR" ]; then
+                cd "\$PREVIEW_DIR"
+                git fetch origin
+                git checkout "${PR_BRANCH}"
+                git reset --hard "origin/${PR_BRANCH}"
+              else
+                git clone --branch "${PR_BRANCH}" "${PR_REPO}" "\$PREVIEW_DIR"
+                cd "\$PREVIEW_DIR"
+              fi
+
+              # Install dependencies and build
+              bundle install --jobs 4
+              RAILS_ENV=production bin/rails db:prepare
+              SECRET_KEY_BASE=\$(cat /opt/previews/.secret_key_base) RAILS_ENV=production bin/rails assets:precompile
+
+              # Write systemd override with PORT and SECRET_KEY_BASE
+              mkdir -p /etc/systemd/system/griffith-preview@${PR_NUMBER}.service.d
+              cat > /etc/systemd/system/griffith-preview@${PR_NUMBER}.service.d/override.conf <<EOF
+            [Service]
+            Environment="PORT=${PORT}"
+            Environment="SECRET_KEY_BASE=\$(cat /opt/previews/.secret_key_base)"
+            EOF
+
+              # Start or restart the preview service
+              systemctl daemon-reload
+              systemctl enable --now griffith-preview@${PR_NUMBER}
+              systemctl restart griffith-preview@${PR_NUMBER}
+
+              # Write nginx server block
+              cat > /etc/nginx/conf.d/preview-pr-${PR_NUMBER}.conf <<EOF
+            server {
+                listen 80;
+                server_name preview-${PR_NUMBER}.griffithict.club;
+
+                location / {
+                    proxy_pass http://127.0.0.1:${PORT};
+                    proxy_set_header Host \\\$host;
+                    proxy_set_header X-Real-IP \\\$remote_addr;
+                    proxy_set_header X-Forwarded-For \\\$proxy_add_x_forwarded_for;
+                    proxy_set_header X-Forwarded-Proto https;
+                }
+            }
+            EOF
+
+              nginx -t && systemctl reload nginx
+            DEPLOY_SCRIPT
+
+            rm -f /tmp/deploy_key
+
+      - name: Comment preview URL
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const prNumber = context.payload.pull_request.number;
+            const url = `https://preview-${prNumber}.griffithict.club`;
+            const body = `## Preview Deployment\n\nThis PR has been deployed to: ${url}\n\nThe preview will be torn down when the \`preview\` label is removed or this PR is closed.`;
+
+            const comments = await github.rest.issues.listComments({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: prNumber,
+            });
+            const existing = comments.data.find(c =>
+              c.user.type === 'Bot' && c.body.includes('Preview Deployment')
+            );
+
+            if (existing) {
+              await github.rest.issues.updateComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                comment_id: existing.id,
+                body,
+              });
+            } else {
+              await github.rest.issues.createComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: prNumber,
+                body,
+              });
+            }
+
+  teardown-preview:
+    if: >
+      (github.event.action == 'unlabeled' && github.event.label.name == 'preview') ||
+      (github.event.action == 'closed' && contains(github.event.pull_request.labels.*.name, 'preview'))
+    runs-on: ubuntu-latest
+    steps:
+      - name: Teardown preview
+        uses: nick-fields/retry@v3
+        env:
+          VPS_SSH_KEY: ${{ secrets.VPS_SSH_KEY }}
+          VPS_HOST: ${{ secrets.VPS_HOST }}
+        with:
+          timeout_minutes: 5
+          max_attempts: 3
+          retry_wait_seconds: 30
+          command: |
+            echo "$VPS_SSH_KEY" > /tmp/deploy_key
+            chmod 600 /tmp/deploy_key
+
+            PR_NUMBER=${{ github.event.pull_request.number }}
+
+            ssh -o StrictHostKeyChecking=no -o ConnectTimeout=30 -i /tmp/deploy_key root@$VPS_HOST bash -s <<TEARDOWN_SCRIPT
+              systemctl stop griffith-preview@${PR_NUMBER} 2>/dev/null || true
+              systemctl disable griffith-preview@${PR_NUMBER} 2>/dev/null || true
+              rm -rf /etc/systemd/system/griffith-preview@${PR_NUMBER}.service.d
+              systemctl daemon-reload
+
+              rm -f /etc/nginx/conf.d/preview-pr-${PR_NUMBER}.conf
+              nginx -t && systemctl reload nginx
+
+              rm -rf /opt/previews/pr-${PR_NUMBER}
+            TEARDOWN_SCRIPT
+
+            rm -f /tmp/deploy_key
+
+      - name: Comment teardown
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const prNumber = context.payload.pull_request.number;
+            const comments = await github.rest.issues.listComments({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: prNumber,
+            });
+            const existing = comments.data.find(c =>
+              c.user.type === 'Bot' && c.body.includes('Preview Deployment')
+            );
+            if (existing) {
+              await github.rest.issues.updateComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                comment_id: existing.id,
+                body: '## Preview Deployment\n\n~~This PR\'s preview has been torn down.~~',
+              });
+            }

--- a/script/vps-preview-setup.sh
+++ b/script/vps-preview-setup.sh
@@ -1,0 +1,56 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+echo "==> Creating preview directory"
+mkdir -p /opt/previews
+
+echo "==> Generating shared SECRET_KEY_BASE"
+if [ ! -f /opt/previews/.secret_key_base ]; then
+  openssl rand -hex 64 > /opt/previews/.secret_key_base
+  chmod 600 /opt/previews/.secret_key_base
+  echo "    Created /opt/previews/.secret_key_base"
+else
+  echo "    Already exists, skipping"
+fi
+
+echo "==> Installing systemd template unit"
+cat > /etc/systemd/system/griffith-preview@.service <<'EOF'
+[Unit]
+Description=Griffith ICT Web Preview (PR %i)
+After=network.target
+
+[Service]
+Type=simple
+User=root
+WorkingDirectory=/opt/previews/pr-%i
+Environment="RAILS_ENV=production"
+ExecStart=/bin/bash -c 'export PATH="$HOME/.rbenv/bin:$HOME/.rbenv/shims:$PATH" && exec bundle exec puma -C config/puma.rb'
+Restart=on-failure
+RestartSec=5
+
+[Install]
+WantedBy=multi-user.target
+EOF
+
+systemctl daemon-reload
+echo "    Installed griffith-preview@.service template"
+
+echo "==> Creating nginx conf.d directory"
+mkdir -p /etc/nginx/conf.d
+
+echo ""
+echo "=== MANUAL STEPS REMAINING ==="
+echo ""
+echo "1. DNS: Add a wildcard A record for *.griffithict.club"
+echo "   pointing to this server's IP address (Cloudflare)."
+echo ""
+echo "2. SSL: Cloudflare Universal SSL covers *.griffithict.club."
+echo "   Ensure the wildcard DNS record is proxied (orange cloud)."
+echo "   Set SSL mode to Full (strict) and use a Cloudflare Origin CA cert on the VPS."
+echo ""
+echo "3. Ensure nginx includes conf.d/*.conf in its http block:"
+echo "   include /etc/nginx/conf.d/*.conf;"
+echo ""
+echo "4. Create a 'preview' label in the GitHub repository."
+echo ""
+echo "Setup complete."

--- a/script/vps-preview-teardown-all.sh
+++ b/script/vps-preview-teardown-all.sh
@@ -1,0 +1,22 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+echo "==> Stopping all preview services"
+for svc in $(systemctl list-units --type=service --all | grep griffith-preview@ | awk '{print $1}'); do
+  echo "    Stopping $svc"
+  systemctl stop "$svc" || true
+  systemctl disable "$svc" || true
+done
+
+echo "==> Removing nginx preview configs"
+rm -f /etc/nginx/conf.d/preview-pr-*.conf
+nginx -t && systemctl reload nginx
+
+echo "==> Removing preview directories"
+rm -rf /opt/previews/pr-*
+
+echo "==> Cleaning up systemd overrides"
+rm -rf /etc/systemd/system/griffith-preview@*.service.d
+systemctl daemon-reload
+
+echo "Done. All previews torn down."


### PR DESCRIPTION
# Overview
Add opt-in preview deployments for PRs. Adding the `preview` label to a PR deploys it to `preview-{number}.griffithict.club`. Previews auto-update on push and tear down when the label is removed or the PR is closed.

# Summary of Changes
- Add `.github/workflows/preview.yml` — GitHub Actions workflow with deploy and teardown jobs triggered by PR label events (`labeled`, `synchronize`, `unlabeled`, `closed`)
- Add `script/vps-preview-setup.sh` — one-time VPS setup script that creates the preview directory, generates a shared secret key, and installs a systemd template unit
- Add `script/vps-preview-teardown-all.sh` — emergency cleanup script to wipe all active previews

# How it works
- Port allocation: `4000 + PR number` (deterministic, no state needed)
- Each preview gets its own directory (`/opt/previews/pr-{number}/`), systemd service (`griffith-preview@{number}`), and nginx config
- Deploy job posts a PR comment with the preview URL
- Teardown job updates the comment to show the preview was removed
- Concurrency group per PR prevents race conditions
- Port range guard fails the workflow if PR number exceeds 1000, with a hint to migrate to Unix sockets

# Setup required (after merge)
1. SSH into VPS and run `bash script/vps-preview-setup.sh`
2. Ensure wildcard DNS `*.griffithict.club` points to VPS IP (Cloudflare, proxied)
3. Ensure Cloudflare SSL is set to Full (strict) with an Origin CA cert on the VPS
4. Create the `preview` label in the GitHub repo

# Testing / QA
- [x] Create a test PR and add the `preview` label
- [x] Verify the workflow runs and a PR comment appears with the preview URL
- [x] Visit `preview-{number}.griffithict.club` and confirm it loads
- [x] Push a new commit and confirm the preview auto-updates
- [x] Remove the `preview` label and confirm teardown runs
- [x] Verify production at `griffithict.club` is unaffected