### PR TITLE
Feature | Preview and development banner

### DIFF
--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -73,6 +73,7 @@ jobs:
             [Service]
             Environment="PORT=${PORT}"
             Environment="SECRET_KEY_BASE=\$(cat /opt/previews/.secret_key_base)"
+            Environment="PREVIEW_PR_NUMBER=${PR_NUMBER}"
             EOF
 
               # Start or restart the preview service

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -30,9 +30,50 @@
     <%# Includes all stylesheet files in app/assets/stylesheets %>
     <%= stylesheet_link_tag :app %>
     <%= javascript_importmap_tags %>
+
+    <% pr_number = ENV["PREVIEW_PR_NUMBER"].presence %>
+    <% preview_env = pr_number ? :preview : (Rails.env.development? ? :development : nil) %>
+    <% if preview_env %>
+      <style>
+        #preview-banner {
+          position: fixed;
+          top: 0;
+          left: 0;
+          right: 0;
+          z-index: 9999;
+          text-align: center;
+          font-size: 0.875rem;
+          font-weight: 700;
+          padding: 0.375rem;
+          background-color: #80E23A;
+        }
+        #preview-banner { color: #000; }
+        #preview-banner a { text-decoration: underline; color: inherit; }
+        body { padding-top: var(--preview-h); }
+        nav[data-controller="navbar"] { top: var(--preview-h) !important; }
+      </style>
+    <% end %>
   </head>
 
   <body class="min-h-screen flex flex-col">
+    <% if preview_env %>
+      <div id="preview-banner">
+        <% if preview_env == :preview %>
+          <div>You are on a preview branch. Information may be outdated or incorrect.</div>
+          <div><a href="<%= meta[:url] %>">Return to griffithict.club</a> · <a href="<%= Rails.application.config.socials[:github] %>pull/<%= pr_number %>" target="_blank" rel="noopener">View PR #<%= pr_number %></a></div>
+        <% else %>
+          <div>You are on a development branch. Information may be outdated or incorrect.</div>
+          <div><a href="<%= meta[:url] %>">Return to griffithict.club</a></div>
+        <% end %>
+      </div>
+      <script>
+        (() => {
+          const update = () => document.documentElement.style.setProperty('--preview-h', document.getElementById('preview-banner').offsetHeight + 'px');
+          update();
+          window.addEventListener('resize', update);
+        })();
+      </script>
+    <% end %>
     <%= render Site::Navbar::Component.new %>
     <%= render Site::MembershipModalComponent.new %>
 


### PR DESCRIPTION
# Overview
Add a fixed green banner to preview and development environments to clearly indicate non-production sites.

# Summary of Changes
- Add a fixed green banner at the top of the page in preview and development environments
- Preview banner shows "You are on a preview branch" with links to return to griffithict.club and view the PR
- Development banner shows "You are on a development branch" with a link to griffithict.club
- Banner height is measured dynamically via JS to offset the fixed navbar correctly on all screen sizes
- Pass `PREVIEW_PR_NUMBER` env var from the preview systemd service to the app
- Banner does not appear in production

# Testing / QA
- [x] Run locally and verify the green development banner appears above the navbar
- [x] Verify the banner resizes correctly on mobile/desktop
- [x] Verify production at griffithict.club has no banner