### PR TITLE
Fix | Perk modal icon flash when switching perks

### DIFF
--- a/app/javascript/controllers/perk_modal_controller.js
+++ b/app/javascript/controllers/perk_modal_controller.js
@@ -11,8 +11,14 @@ export default class extends Controller {
     const card = event.currentTarget
     const { perkName, perkIcon, perkDescription, perkWebsite } = card.dataset
 
-    this.iconTarget.src = perkIcon
+    this.iconTarget.style.opacity = "0"
     this.iconTarget.alt = perkName
+    const img = new Image()
+    img.src = perkIcon
+    img.onload = () => {
+      this.iconTarget.src = perkIcon
+      this.iconTarget.style.opacity = "1"
+    }
     this.nameTarget.textContent = perkName
     this.descriptionTarget.textContent = perkDescription
     this.linkTarget.href = perkWebsite


### PR DESCRIPTION
# Overview
Fixes the perk modal briefly showing the previous perk's icon when switching between perks.

# Summary of Changes
- Preload the new icon via a hidden `Image` object before updating the `src` attribute
- Icon is hidden during load and revealed once the new image is ready
- Cached images appear instantly on subsequent opens

# Testing / QA
- [x] Click a perk card and verify the modal opens with the correct icon
- [x] Close and immediately open a different perk — verify no flash of the previous icon
- [x] Rapidly switch between perks and verify icons are always correct