### PR TITLE
Fix | Preview teardown on close and fork auto-redeploy protection

### DIFF
--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -12,10 +12,32 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  remove-label-on-fork-push:
+    if: >
+      github.event.action == 'synchronize' &&
+      contains(github.event.pull_request.labels.*.name, 'preview') &&
+      github.event.pull_request.head.repo.full_name != github.repository
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write
+    steps:
+      - name: Remove preview label
+        uses: actions/github-script@v7
+        with:
+          script: |
+            await github.rest.issues.removeLabel({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.payload.pull_request.number,
+              name: 'preview',
+            });
+
   deploy-preview:
     if: >
       (github.event.action == 'labeled' && github.event.label.name == 'preview') ||
-      (github.event.action == 'synchronize' && contains(github.event.pull_request.labels.*.name, 'preview'))
+      (github.event.action == 'synchronize' &&
+       contains(github.event.pull_request.labels.*.name, 'preview') &&
+       github.event.pull_request.head.repo.full_name == github.repository)
     runs-on: ubuntu-latest
     steps:
       # Port allocation: 4000 + PR number. When this limit is hit, switch to
@@ -131,7 +153,7 @@ jobs:
   teardown-preview:
     if: >
       (github.event.action == 'unlabeled' && github.event.label.name == 'preview') ||
-      (github.event.action == 'closed' && contains(github.event.pull_request.labels.*.name, 'preview'))
+      github.event.action == 'closed'
     runs-on: ubuntu-latest
     steps:
       - name: Teardown preview


### PR DESCRIPTION
# Overview
Fixes preview deployments not being torn down on PR close, and prevents fork PRs from auto-redeploying on push.

# Summary of Changes
- Always run teardown on PR close, regardless of whether the `preview` label is present in the event payload
- Add `remove-label-on-fork-push` job: when a fork PR with the `preview` label receives a push, the label is automatically removed (triggering teardown)
- Same-repo branches continue to auto-redeploy on push as before

# How fork previews work now
1. Maintainer reviews a fork PR, adds `preview` label → deploys
2. Fork contributor pushes new commits → label is removed → preview torn down
3. Maintainer reviews new code, re-adds label → deploys again

# Testing / QA
- [x] Close a PR with the `preview` label and verify the preview is torn down
- [x] Close a PR without the `preview` label and verify the teardown runs harmlessly
- [x] Verify same-repo PRs still auto-redeploy on push when labeled