### PR TITLE
Fix | Mobile Nav - simplify layout and fix dropdown spacing

### DIFF
--- a/app/components/site/navbar/mobile_component.html.erb
+++ b/app/components/site/navbar/mobile_component.html.erb
@@ -1,33 +1,39 @@
-<div data-navbar-target="menu" class="fixed inset-0 z-10 flex flex-col items-center justify-center gap-8 bg-brand-bg opacity-0 pointer-events-none transition-all duration-500 md:hidden heading">
-  <% links.each do |link| %>
-    <% if link[:children] %>
-      <div data-controller="dropdown" class="flex flex-col items-center">
-        <button data-action="dropdown#toggle" class="text-2xl font-bold text-brand-black hover:text-brand-red transition-colors inline-flex items-center gap-2 cursor-pointer">
-          <%= link[:label] %>
-          <svg data-dropdown-target="chevron" class="w-5 h-5 transition-transform duration-200" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2.5">
-            <path stroke-linecap="round" stroke-linejoin="round" d="M19 9l-7 7-7-7" />
-          </svg>
-        </button>
-        <div data-dropdown-target="menu" class="grid grid-rows-[0fr] transition-[grid-template-rows,opacity] duration-300 opacity-0">
-          <div class="overflow-hidden flex flex-col items-center pt-2">
-            <% link[:children].each do |child| %>
-              <a href="<%= child[:href] %>" class="text-lg font-bold hover:text-brand-red transition-colors py-2" data-action="navbar#closeMenu">
-                <%= child[:label] %>
-              </a>
-            <% end %>
+<nav data-navbar-target="menu" class="fixed inset-0 z-10 flex flex-col items-center justify-center bg-brand-bg opacity-0 pointer-events-none transition-all duration-500 md:hidden heading">
+  <ul class="flex flex-col items-center text-center">
+    <% links.each do |link| %>
+      <li>
+        <% if link[:children] %>
+          <div data-controller="dropdown">
+            <button data-action="dropdown#toggle" class="text-2xl font-bold text-brand-black hover:text-brand-red transition-colors inline-flex items-center gap-2 cursor-pointer py-3">
+              <%= link[:label] %>
+              <svg data-dropdown-target="chevron" class="w-5 h-5 transition-transform duration-200" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2.5">
+                <path stroke-linecap="round" stroke-linejoin="round" d="M19 9l-7 7-7-7" />
+              </svg>
+            </button>
+            <div data-dropdown-target="menu" class="grid grid-rows-[0fr] transition-[grid-template-rows,opacity] duration-300 opacity-0">
+              <div class="overflow-hidden flex flex-col items-center">
+                <% link[:children].each do |child| %>
+                  <a href="<%= child[:href] %>" class="text-lg font-bold hover:text-brand-red transition-colors py-2" data-action="navbar#closeMenu">
+                    <%= child[:label] %>
+                  </a>
+                <% end %>
+              </div>
+            </div>
           </div>
-        </div>
-      </div>
-    <% else %>
-      <a href="<%= link[:href] %>" class="text-2xl font-bold text-brand-black hover:text-brand-red transition-colors" data-action="navbar#closeMenu">
-        <%= link[:label] %>
-      </a>
+        <% else %>
+          <a href="<%= link[:href] %>" class="text-2xl font-bold text-brand-black hover:text-brand-red transition-colors block py-3" data-action="navbar#closeMenu">
+            <%= link[:label] %>
+          </a>
+        <% end %>
+      </li>
     <% end %>
-  <% end %>
+  </ul>
 
-  <% if helpers.authenticated? %>
-    <a href="<%= helpers.account_path %>" class="btn btn-secondary" data-action="navbar#closeMenu">Account</a>
-  <% else %>
-    <button class="btn btn-primary" data-action="navbar#closeMenu" onclick="window.dispatchEvent(new CustomEvent('membership-modal:open'))"><%= cta[:label] %></button>
-  <% end %>
-</div>
+  <div class="mt-8">
+    <% if helpers.authenticated? %>
+      <a href="<%= helpers.account_path %>" class="btn btn-secondary" data-action="navbar#closeMenu">Account</a>
+    <% else %>
+      <button class="btn btn-primary" data-action="navbar#closeMenu" onclick="window.dispatchEvent(new CustomEvent('membership-modal:open'))"><%= cta[:label] %></button>
+    <% end %>
+  </div>
+</nav>


### PR DESCRIPTION
Closes #59

# Overview
The mobile nav had inconsistent spacing under dropdown items compared to regular links. The `gap-8` on the parent flex container created uneven visual spacing because dropdown wrappers had internal structure (collapsed grid) that regular links didn't.

# Summary of Changes
- Replaced flex gap-based layout with a proper `<nav>` + `<ul>` structure
- Both dropdown buttons and plain links use `py-3` for consistent spacing
- Removed extra padding hacks from dropdown internals
- CTA button separated with `mt-8`

# Testing/QA
- [x] Open mobile nav: all top-level items should be evenly spaced
- [x] Dropdown items (About, Sponsors) visually match non-dropdown items
- [x] All links navigate correctly and close the menu
- [x] CTA button works (opens membership modal)