### PR TITLE
Update Gold Coast committee and team layout

### DIFF
--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -61,7 +61,9 @@ jobs:
           max_attempts: 3
           retry_wait_seconds: 30
           command: |
+            set -euo pipefail
             echo "$VPS_SSH_KEY" > /tmp/deploy_key
+            trap 'rm -f /tmp/deploy_key' EXIT
             chmod 600 /tmp/deploy_key
 
             PR_NUMBER=${{ github.event.pull_request.number }}
@@ -132,8 +134,6 @@ jobs:
 
               nginx -t && systemctl reload nginx
             DEPLOY_SCRIPT
-
-            rm -f /tmp/deploy_key
 
       - name: Add preview URL to PR description
         uses: actions/github-script@v7

--- a/app/views/about/_team.html.erb
+++ b/app/views/about/_team.html.erb
@@ -1,3 +1,24 @@
+<%
+  balanced_team_rows = lambda do |members|
+    remaining = members.dup
+    rows = []
+
+    while remaining.length > 4
+      rows << remaining.shift(remaining.length == 5 ? 3 : 4)
+    end
+
+    rows << remaining if remaining.any?
+    rows
+  end
+
+  team_row_columns = {
+    1 => "md:grid-cols-1",
+    2 => "md:grid-cols-2",
+    3 => "md:grid-cols-3",
+    4 => "md:grid-cols-4"
+  }
+%>
+
 <section id="team" data-controller="tabs">
   <div class="container">
     <div class="mb-12 reveal">
@@ -24,25 +45,29 @@
             <span class="badge badge-sm">ELECTED</span>
             <p class="text-sm mt-2">Voted on by members at the Annual General Meeting.</p>
           </div>
-          <div class="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-4 gap-5 reveal stagger <%= 'mb-12' if campus["appointed"]&.any? %>">
-            <% campus["elected"].each do |member| %>
-              <div>
-                <% unassigned = member["name"].nil? %>
-                <% if unassigned %>
-                  <div class="p-6 border-3 border-dashed border-brand-gray/30 bg-brand-cream">
-                    <div class="w-10 h-10 bg-brand-gray/10 flex items-center justify-center mb-4">
-                      <%= icon(member["icon"], class: "w-5 h-5 opacity-40") %>
-                    </div>
-                    <h3 class="heading heading-4"><%= member["role"] %></h3>
-                    <p class="text-brand-gray/50 text-sm italic">Unassigned</p>
-                  </div>
-                <% else %>
-                  <div class="card" style="box-shadow: 5px 5px 0px var(--color-brand-red);">
-                    <div class="w-10 h-10 bg-brand-red/10 flex items-center justify-center mb-4">
-                      <%= icon(member["icon"], class: "w-5 h-5 text-brand-red") %>
-                    </div>
-                    <h3 class="heading heading-4"><%= member["role"] %></h3>
-                    <p class="text-sm"><%= member["name"] %></p>
+          <div class="flex flex-col gap-5 reveal stagger <%= 'mb-12' if campus["appointed"]&.any? %>">
+            <% balanced_team_rows.call(campus["elected"]).each do |row| %>
+              <div class="grid grid-cols-1 sm:grid-cols-2 <%= team_row_columns.fetch(row.length) %> gap-5">
+                <% row.each do |member| %>
+                  <div>
+                    <% unassigned = member["name"].nil? %>
+                    <% if unassigned %>
+                      <div class="p-6 border-3 border-dashed border-brand-gray/30 bg-brand-cream h-full">
+                        <div class="w-10 h-10 bg-brand-gray/10 flex items-center justify-center mb-4">
+                          <%= icon(member["icon"], class: "w-5 h-5 opacity-40") %>
+                        </div>
+                        <h3 class="heading heading-4"><%= member["role"] %></h3>
+                        <p class="text-brand-gray/50 text-sm italic">Unassigned</p>
+                      </div>
+                    <% else %>
+                      <div class="card" style="box-shadow: 5px 5px 0px var(--color-brand-red);">
+                        <div class="w-10 h-10 bg-brand-red/10 flex items-center justify-center mb-4">
+                          <%= icon(member["icon"], class: "w-5 h-5 text-brand-red") %>
+                        </div>
+                        <h3 class="heading heading-4"><%= member["role"] %></h3>
+                        <p class="text-sm"><%= member["name"] %></p>
+                      </div>
+                    <% end %>
                   </div>
                 <% end %>
               </div>
@@ -55,25 +80,29 @@
             <span class="badge badge-dark badge-sm">APPOINTED</span>
             <p class="text-sm mt-2">Voted on by the executive team. Applications are opened as needed.</p>
           </div>
-          <div class="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 gap-5 reveal stagger">
-            <% campus["appointed"].each do |member| %>
-              <div>
-                <% unassigned = member["name"].nil? %>
-                <% if unassigned %>
-                  <div class="p-6 border-3 border-dashed border-brand-gray/30 bg-brand-cream">
-                    <div class="w-10 h-10 bg-brand-gray/10 flex items-center justify-center mb-4">
-                      <%= icon(member["icon"], class: "w-5 h-5 opacity-40") %>
-                    </div>
-                    <h3 class="heading heading-4"><%= member["role"] %></h3>
-                    <p class="text-brand-gray/50 text-sm italic">Unassigned</p>
-                  </div>
-                <% else %>
-                  <div class="card" style="box-shadow: 5px 5px 0px var(--color-brand-red-300);">
-                    <div class="w-10 h-10 bg-brand-red/10 flex items-center justify-center mb-4">
-                      <%= icon(member["icon"], class: "w-5 h-5 text-brand-red") %>
-                    </div>
-                    <h3 class="heading heading-4"><%= member["role"] %></h3>
-                    <p class="text-sm"><%= member["name"] %></p>
+          <div class="flex flex-col gap-5 reveal stagger">
+            <% balanced_team_rows.call(campus["appointed"]).each do |row| %>
+              <div class="grid grid-cols-1 sm:grid-cols-2 <%= team_row_columns.fetch(row.length) %> gap-5">
+                <% row.each do |member| %>
+                  <div>
+                    <% unassigned = member["name"].nil? %>
+                    <% if unassigned %>
+                      <div class="p-6 border-3 border-dashed border-brand-gray/30 bg-brand-cream h-full">
+                        <div class="w-10 h-10 bg-brand-gray/10 flex items-center justify-center mb-4">
+                          <%= icon(member["icon"], class: "w-5 h-5 opacity-40") %>
+                        </div>
+                        <h3 class="heading heading-4"><%= member["role"] %></h3>
+                        <p class="text-brand-gray/50 text-sm italic">Unassigned</p>
+                      </div>
+                    <% else %>
+                      <div class="card" style="box-shadow: 5px 5px 0px var(--color-brand-red-300);">
+                        <div class="w-10 h-10 bg-brand-red/10 flex items-center justify-center mb-4">
+                          <%= icon(member["icon"], class: "w-5 h-5 text-brand-red") %>
+                        </div>
+                        <h3 class="heading heading-4"><%= member["role"] %></h3>
+                        <p class="text-sm"><%= member["name"] %></p>
+                      </div>
+                    <% end %>
                   </div>
                 <% end %>
               </div>

--- a/config/team.yml
+++ b/config/team.yml
@@ -8,7 +8,7 @@ campuses:
         name: Tylar Pinniger
         icon: shield
       - role: Treasurer
-        name: ~
+        name: Novak Bigic
         icon: wallet
       - role: Secretary
         name: Julio Medeiros

--- a/config/team.yml
+++ b/config/team.yml
@@ -2,16 +2,16 @@ campuses:
   - name: Gold Coast
     elected:
       - role: President
-        name: Owen Richardson
+        name: William Jackson
         icon: crown
       - role: Vice President
         name: Tylar Pinniger
         icon: shield
       - role: Treasurer
-        name: William Jackson
+        name: ~
         icon: wallet
       - role: Secretary
-        name: Zain Abrahams
+        name: Julio Medeiros
         icon: file-text
     appointed:
       - role: Events Co-ordinator
@@ -20,10 +20,6 @@ campuses:
       - role: Social Media Manager
         name: ~
         icon: megaphone
-      - role: Industry Liaison
-        name: Julio Medeiros
-        icon: briefcase
-
   - name: Brisbane
     elected:
       - role: President


### PR DESCRIPTION
## Summary

- appoint William Jackson as acting Gold Coast President
- appoint Novak Bigic as acting Gold Coast Treasurer
- appoint Julio Medeiros as acting Gold Coast Secretary
- remove Owen Richardson and Zain Abrahams from the current committee
- remove the Gold Coast Industry Liaison role
- balance team-card rows responsively with a maximum of four cards per row
- ensure partial rows expand evenly across the available width
- make preview deployment failures propagate and retry correctly

## Verification

- validated all requested card distributions from one through nine cards
- verified the deployed Gold Coast appointed row uses two equal-width columns
- passed preview deployment and repository checks