### PR TITLE
Add interactive team role details and history

### DIFF
--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -61,7 +61,9 @@ jobs:
           max_attempts: 3
           retry_wait_seconds: 30
           command: |
+            set -euo pipefail
             echo "$VPS_SSH_KEY" > /tmp/deploy_key
+            trap 'rm -f /tmp/deploy_key' EXIT
             chmod 600 /tmp/deploy_key
 
             PR_NUMBER=${{ github.event.pull_request.number }}
@@ -132,8 +134,6 @@ jobs:
 
               nginx -t && systemctl reload nginx
             DEPLOY_SCRIPT
-
-            rm -f /tmp/deploy_key
 
       - name: Add preview URL to PR description
         uses: actions/github-script@v7

--- a/app/assets/tailwind/application.css
+++ b/app/assets/tailwind/application.css
@@ -104,6 +104,11 @@ main > section:nth-of-type(odd) {
 }
 .btn-primary { @apply bg-brand-red text-white hover:shadow-[5px_5px_0px_var(--color-brand-black)]; }
 .btn-secondary { @apply bg-white text-brand-black hover:shadow-[5px_5px_0px_var(--color-brand-red)]; }
+.btn-disabled,
+.btn-disabled:hover,
+.btn-disabled:active {
+  @apply bg-brand-cream border-brand-gray/30 text-brand-gray/50 translate-y-0 shadow-none cursor-not-allowed;
+}
 .btn-sm { @apply px-5 py-2.5 text-sm; }
 
 .badge {

--- a/app/controllers/about_controller.rb
+++ b/app/controllers/about_controller.rb
@@ -2,6 +2,8 @@ class AboutController < ApplicationController
   allow_unauthenticated_access
 
   def show
-    @team = YAML.load_file(Rails.root.join("config/team.yml"))["campuses"]
+    team_config = YAML.load_file(Rails.root.join("config/team.yml"))
+    @team = team_config["campuses"]
+    @team_roles = team_config["roles"]
   end
 end

--- a/app/javascript/controllers/role_modal_controller.js
+++ b/app/javascript/controllers/role_modal_controller.js
@@ -44,15 +44,26 @@ export default class extends Controller {
         const marker = document.createElement("span")
         marker.className = "absolute -left-[7px] top-1.5 w-3 h-3 bg-brand-red border-2 border-brand-bg"
 
+        const nameRow = document.createElement("div")
+        nameRow.className = "flex flex-wrap items-center gap-2"
+
         const name = document.createElement("p")
         name.className = "font-bold text-brand-black"
         name.textContent = entry.name
+        nameRow.append(name)
+
+        if (entry.acting) {
+          const actingBadge = document.createElement("span")
+          actingBadge.className = "inline-flex bg-brand-red/10 text-brand-red px-2 py-0.5 text-xs font-bold uppercase"
+          actingBadge.textContent = "Acting"
+          nameRow.append(actingBadge)
+        }
 
         const period = document.createElement("p")
         period.className = "text-sm"
         period.textContent = entry.period
 
-        item.append(marker, name, period)
+        item.append(marker, nameRow, period)
         return item
       })
     )

--- a/app/javascript/controllers/role_modal_controller.js
+++ b/app/javascript/controllers/role_modal_controller.js
@@ -59,15 +59,16 @@ export default class extends Controller {
       ...JSON.parse(card.dataset.history).reverse().map((entry) => {
         const item = document.createElement("li")
         item.className = "relative pl-6 pb-5 last:pb-0"
+        const isUnassigned = entry.name === "Unassigned"
 
         const marker = document.createElement("span")
-        marker.className = "absolute -left-[7px] top-1.5 w-3 h-3 bg-brand-red border-2 border-brand-bg"
+        marker.className = `absolute -left-[7px] top-1.5 w-3 h-3 border-2 border-brand-bg ${isUnassigned ? "bg-brand-gray/30" : "bg-brand-red"}`
 
         const nameRow = document.createElement("div")
         nameRow.className = "flex flex-wrap items-center gap-2"
 
         const name = document.createElement("p")
-        name.className = "font-bold text-brand-black"
+        name.className = isUnassigned ? "font-semibold italic text-brand-gray/50" : "font-bold text-brand-black"
         name.textContent = entry.name
         nameRow.append(name)
 

--- a/app/javascript/controllers/role_modal_controller.js
+++ b/app/javascript/controllers/role_modal_controller.js
@@ -37,7 +37,7 @@ export default class extends Controller {
     const roleIsUnassigned = card.dataset.memberName === "Unassigned"
     this.applicationActionsTarget.classList.toggle("hidden", !roleIsUnassigned)
     this.timelineTarget.replaceChildren(
-      ...JSON.parse(card.dataset.history).map((entry) => {
+      ...JSON.parse(card.dataset.history).reverse().map((entry) => {
         const item = document.createElement("li")
         item.className = "relative pl-6 pb-5 last:pb-0"
 

--- a/app/javascript/controllers/role_modal_controller.js
+++ b/app/javascript/controllers/role_modal_controller.js
@@ -8,8 +8,7 @@ export default class extends Controller {
     "member",
     "responsibilities",
     "applicationActions",
-    "applicationsOpen",
-    "applicationsClosed"
+    "timeline"
   ]
 
   connect() {
@@ -36,12 +35,27 @@ export default class extends Controller {
     )
 
     const roleIsUnassigned = card.dataset.memberName === "Unassigned"
-    const applicationsAreOpen = card.dataset.applicationStatus === "open" && card.dataset.applicationUrl
-
     this.applicationActionsTarget.classList.toggle("hidden", !roleIsUnassigned)
-    this.applicationsOpenTarget.classList.toggle("hidden", !applicationsAreOpen)
-    this.applicationsClosedTarget.classList.toggle("hidden", applicationsAreOpen)
-    this.applicationsOpenTarget.href = applicationsAreOpen ? card.dataset.applicationUrl : "#"
+    this.timelineTarget.replaceChildren(
+      ...JSON.parse(card.dataset.history).map((entry) => {
+        const item = document.createElement("li")
+        item.className = "relative pl-6 pb-5 last:pb-0"
+
+        const marker = document.createElement("span")
+        marker.className = "absolute -left-[7px] top-1.5 w-3 h-3 bg-brand-red border-2 border-brand-bg"
+
+        const name = document.createElement("p")
+        name.className = "font-bold text-brand-black"
+        name.textContent = entry.name
+
+        const period = document.createElement("p")
+        period.className = "text-sm"
+        period.textContent = entry.period
+
+        item.append(marker, name, period)
+        return item
+      })
+    )
 
     this.backdropTarget.classList.remove("opacity-0", "pointer-events-none")
     this.backdropTarget.classList.add("opacity-100", "pointer-events-auto")

--- a/app/javascript/controllers/role_modal_controller.js
+++ b/app/javascript/controllers/role_modal_controller.js
@@ -1,7 +1,7 @@
 import { Controller } from "@hotwired/stimulus"
 
 export default class extends Controller {
-  static targets = ["backdrop", "panel", "title", "responsibilities", "note", "close"]
+  static targets = ["backdrop", "panel", "title", "member", "responsibilities"]
 
   connect() {
     this.handleKeydown = this.handleKeydown.bind(this)
@@ -17,6 +17,7 @@ export default class extends Controller {
 
     this.previouslyFocused = card
     this.titleTarget.textContent = card.dataset.role
+    this.memberTarget.textContent = card.dataset.memberName
     this.responsibilitiesTarget.replaceChildren(
       ...JSON.parse(card.dataset.responsibilities).map((responsibility) => {
         const item = document.createElement("li")
@@ -25,14 +26,6 @@ export default class extends Controller {
       })
     )
 
-    if (card.dataset.note) {
-      this.noteTarget.textContent = card.dataset.note
-      this.noteTarget.classList.remove("hidden")
-    } else {
-      this.noteTarget.textContent = ""
-      this.noteTarget.classList.add("hidden")
-    }
-
     this.backdropTarget.classList.remove("opacity-0", "pointer-events-none")
     this.backdropTarget.classList.add("opacity-100", "pointer-events-auto")
     this.panelTarget.classList.remove("scale-95", "opacity-0")
@@ -40,7 +33,7 @@ export default class extends Controller {
     this.backdropTarget.setAttribute("aria-hidden", "false")
     document.body.classList.add("overflow-hidden")
     document.addEventListener("keydown", this.handleKeydown)
-    this.closeTarget.focus()
+    this.panelTarget.focus()
   }
 
   close() {
@@ -60,9 +53,5 @@ export default class extends Controller {
 
   handleKeydown(event) {
     if (event.key === "Escape") this.close()
-    if (event.key === "Tab") {
-      event.preventDefault()
-      this.closeTarget.focus()
-    }
   }
 }

--- a/app/javascript/controllers/role_modal_controller.js
+++ b/app/javascript/controllers/role_modal_controller.js
@@ -1,7 +1,16 @@
 import { Controller } from "@hotwired/stimulus"
 
 export default class extends Controller {
-  static targets = ["backdrop", "panel", "title", "member", "responsibilities"]
+  static targets = [
+    "backdrop",
+    "panel",
+    "title",
+    "member",
+    "responsibilities",
+    "applicationActions",
+    "applicationsOpen",
+    "applicationsClosed"
+  ]
 
   connect() {
     this.handleKeydown = this.handleKeydown.bind(this)
@@ -25,6 +34,14 @@ export default class extends Controller {
         return item
       })
     )
+
+    const roleIsUnassigned = card.dataset.memberName === "Unassigned"
+    const applicationsAreOpen = card.dataset.applicationStatus === "open" && card.dataset.applicationUrl
+
+    this.applicationActionsTarget.classList.toggle("hidden", !roleIsUnassigned)
+    this.applicationsOpenTarget.classList.toggle("hidden", !applicationsAreOpen)
+    this.applicationsClosedTarget.classList.toggle("hidden", applicationsAreOpen)
+    this.applicationsOpenTarget.href = applicationsAreOpen ? card.dataset.applicationUrl : "#"
 
     this.backdropTarget.classList.remove("opacity-0", "pointer-events-none")
     this.backdropTarget.classList.add("opacity-100", "pointer-events-auto")

--- a/app/javascript/controllers/role_modal_controller.js
+++ b/app/javascript/controllers/role_modal_controller.js
@@ -1,0 +1,68 @@
+import { Controller } from "@hotwired/stimulus"
+
+export default class extends Controller {
+  static targets = ["backdrop", "panel", "title", "responsibilities", "note", "close"]
+
+  connect() {
+    this.handleKeydown = this.handleKeydown.bind(this)
+  }
+
+  disconnect() {
+    document.body.classList.remove("overflow-hidden")
+    document.removeEventListener("keydown", this.handleKeydown)
+  }
+
+  open(event) {
+    const card = event.currentTarget
+
+    this.previouslyFocused = card
+    this.titleTarget.textContent = card.dataset.role
+    this.responsibilitiesTarget.replaceChildren(
+      ...JSON.parse(card.dataset.responsibilities).map((responsibility) => {
+        const item = document.createElement("li")
+        item.textContent = responsibility
+        return item
+      })
+    )
+
+    if (card.dataset.note) {
+      this.noteTarget.textContent = card.dataset.note
+      this.noteTarget.classList.remove("hidden")
+    } else {
+      this.noteTarget.textContent = ""
+      this.noteTarget.classList.add("hidden")
+    }
+
+    this.backdropTarget.classList.remove("opacity-0", "pointer-events-none")
+    this.backdropTarget.classList.add("opacity-100", "pointer-events-auto")
+    this.panelTarget.classList.remove("scale-95", "opacity-0")
+    this.panelTarget.classList.add("scale-100", "opacity-100")
+    this.backdropTarget.setAttribute("aria-hidden", "false")
+    document.body.classList.add("overflow-hidden")
+    document.addEventListener("keydown", this.handleKeydown)
+    this.closeTarget.focus()
+  }
+
+  close() {
+    this.backdropTarget.classList.add("opacity-0", "pointer-events-none")
+    this.backdropTarget.classList.remove("opacity-100", "pointer-events-auto")
+    this.panelTarget.classList.add("scale-95", "opacity-0")
+    this.panelTarget.classList.remove("scale-100", "opacity-100")
+    this.backdropTarget.setAttribute("aria-hidden", "true")
+    document.body.classList.remove("overflow-hidden")
+    document.removeEventListener("keydown", this.handleKeydown)
+    this.previouslyFocused?.focus()
+  }
+
+  closeBackdrop(event) {
+    if (event.target === this.backdropTarget) this.close()
+  }
+
+  handleKeydown(event) {
+    if (event.key === "Escape") this.close()
+    if (event.key === "Tab") {
+      event.preventDefault()
+      this.closeTarget.focus()
+    }
+  }
+}

--- a/app/javascript/controllers/role_modal_controller.js
+++ b/app/javascript/controllers/role_modal_controller.js
@@ -34,8 +34,27 @@ export default class extends Controller {
       })
     )
 
-    const roleIsUnassigned = card.dataset.memberName === "Unassigned"
-    this.applicationActionsTarget.classList.toggle("hidden", !roleIsUnassigned)
+    const applicationsAreOpen = card.dataset.applicationStatus === "open" && card.dataset.applicationUrl
+    const shouldShowApplications = card.dataset.roleType === "appointed" || applicationsAreOpen
+
+    this.applicationActionsTarget.classList.toggle("hidden", !shouldShowApplications)
+    this.applicationActionsTarget.replaceChildren()
+
+    if (shouldShowApplications) {
+      const applicationControl = document.createElement(applicationsAreOpen ? "a" : "button")
+      applicationControl.className = applicationsAreOpen ? "btn btn-primary w-full" : "btn btn-disabled w-full"
+      applicationControl.textContent = applicationsAreOpen ? "Applications open" : "Applications closed"
+
+      if (applicationsAreOpen) {
+        applicationControl.href = card.dataset.applicationUrl
+      } else {
+        applicationControl.type = "button"
+        applicationControl.disabled = true
+      }
+
+      this.applicationActionsTarget.append(applicationControl)
+    }
+
     this.timelineTarget.replaceChildren(
       ...JSON.parse(card.dataset.history).reverse().map((entry) => {
         const item = document.createElement("li")
@@ -61,7 +80,8 @@ export default class extends Controller {
 
         const period = document.createElement("p")
         period.className = "text-sm"
-        period.textContent = entry.period
+        const duration = this.formatDuration(entry.period)
+        period.textContent = duration ? `${entry.period} · ${duration}` : entry.period
 
         item.append(marker, nameRow, period)
         return item
@@ -95,5 +115,27 @@ export default class extends Controller {
 
   handleKeydown(event) {
     if (event.key === "Escape") this.close()
+  }
+
+  formatDuration(period) {
+    if (!period.includes(" - ")) return null
+
+    const months = ["Jan", "Feb", "Mar", "Apr", "May", "Jun", "Jul", "Aug", "Sep", "Oct", "Nov", "Dec"]
+    const [start, end] = period.split(" - ")
+    const [startMonth, startYear] = start.split(" ")
+    const now = new Date()
+    const [endMonth, endYear] = end === "Present"
+      ? [months[now.getMonth()], now.getFullYear().toString()]
+      : end.split(" ")
+
+    const monthCount = ((Number(endYear) - Number(startYear)) * 12) + months.indexOf(endMonth) - months.indexOf(startMonth) + 1
+    const years = Math.floor(monthCount / 12)
+    const remainingMonths = monthCount % 12
+    const parts = []
+
+    if (years) parts.push(`${years} yr${years === 1 ? "" : "s"}`)
+    if (remainingMonths) parts.push(`${remainingMonths} mo${remainingMonths === 1 ? "" : "s"}`)
+
+    return parts.join(" ")
   }
 }

--- a/app/views/about/_team.html.erb
+++ b/app/views/about/_team.html.erb
@@ -165,7 +165,7 @@
         <button data-role-modal-target="applicationsClosed"
                 type="button"
                 disabled
-                class="btn btn-secondary w-full disabled:bg-brand-cream disabled:border-brand-gray/30 disabled:text-brand-gray/50 disabled:cursor-not-allowed disabled:hover:translate-y-0 disabled:hover:shadow-none disabled:active:translate-y-0 disabled:active:shadow-none">
+                class="btn btn-disabled w-full">
           Applications (closed)
         </button>
       </div>

--- a/app/views/about/_team.html.erb
+++ b/app/views/about/_team.html.erb
@@ -159,17 +159,17 @@
       <p data-role-modal-target="member" class="font-semibold text-brand-red"></p>
       <ul data-role-modal-target="responsibilities" class="list-disc pl-5 space-y-3 mt-6"></ul>
 
-      <div class="mt-8 pt-6 border-t-3 border-brand-cream">
-        <h3 class="heading heading-5">Role history</h3>
-        <ol data-role-modal-target="timeline" class="ml-2 border-l-2 border-brand-gray/30"></ol>
-      </div>
-
       <div data-role-modal-target="applicationActions" class="hidden mt-8 pt-6 border-t-3 border-brand-cream">
         <button type="button"
                 disabled
                 class="btn btn-disabled w-full">
           Applications (closed)
         </button>
+      </div>
+
+      <div class="mt-8 pt-6 border-t-3 border-brand-cream">
+        <h3 class="heading heading-5">Role history</h3>
+        <ol data-role-modal-target="timeline" class="ml-2 border-l-2 border-brand-gray/30"></ol>
       </div>
     </div>
   </div>

--- a/app/views/about/_team.html.erb
+++ b/app/views/about/_team.html.erb
@@ -165,7 +165,7 @@
         <button data-role-modal-target="applicationsClosed"
                 type="button"
                 disabled
-                class="btn btn-secondary w-full opacity-50 disabled:cursor-not-allowed disabled:hover:translate-y-0 disabled:hover:shadow-none disabled:active:translate-y-0 disabled:active:shadow-none">
+                class="btn btn-secondary w-full disabled:bg-brand-cream disabled:border-brand-gray/30 disabled:text-brand-gray/50 disabled:cursor-not-allowed disabled:hover:translate-y-0 disabled:hover:shadow-none disabled:active:translate-y-0 disabled:active:shadow-none">
           Applications (closed)
         </button>
       </div>

--- a/app/views/about/_team.html.erb
+++ b/app/views/about/_team.html.erb
@@ -1,3 +1,24 @@
+<%
+  balanced_team_rows = lambda do |members|
+    remaining = members.dup
+    rows = []
+
+    while remaining.length > 4
+      rows << remaining.shift(remaining.length == 5 ? 3 : 4)
+    end
+
+    rows << remaining if remaining.any?
+    rows
+  end
+
+  team_row_columns = {
+    1 => "md:grid-cols-1",
+    2 => "md:grid-cols-2",
+    3 => "md:grid-cols-3",
+    4 => "md:grid-cols-4"
+  }
+%>
+
 <section id="team" data-controller="tabs">
   <div class="container">
     <div class="mb-12 reveal">
@@ -24,25 +45,29 @@
             <span class="badge badge-sm">ELECTED</span>
             <p class="text-sm mt-2">Voted on by members at the Annual General Meeting.</p>
           </div>
-          <div class="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-4 gap-5 reveal stagger <%= 'mb-12' if campus["appointed"]&.any? %>">
-            <% campus["elected"].each do |member| %>
-              <div>
-                <% unassigned = member["name"].nil? %>
-                <% if unassigned %>
-                  <div class="p-6 border-3 border-dashed border-brand-gray/30 bg-brand-cream">
-                    <div class="w-10 h-10 bg-brand-gray/10 flex items-center justify-center mb-4">
-                      <%= icon(member["icon"], class: "w-5 h-5 opacity-40") %>
-                    </div>
-                    <h3 class="heading heading-4"><%= member["role"] %></h3>
-                    <p class="text-brand-gray/50 text-sm italic">Unassigned</p>
-                  </div>
-                <% else %>
-                  <div class="card" style="box-shadow: 5px 5px 0px var(--color-brand-red);">
-                    <div class="w-10 h-10 bg-brand-red/10 flex items-center justify-center mb-4">
-                      <%= icon(member["icon"], class: "w-5 h-5 text-brand-red") %>
-                    </div>
-                    <h3 class="heading heading-4"><%= member["role"] %></h3>
-                    <p class="text-sm"><%= member["name"] %></p>
+          <div class="flex flex-col gap-5 reveal stagger <%= 'mb-12' if campus["appointed"]&.any? %>">
+            <% balanced_team_rows.call(campus["elected"]).each do |row| %>
+              <div class="grid grid-cols-1 sm:grid-cols-2 <%= team_row_columns.fetch(row.length) %> gap-5">
+                <% row.each do |member| %>
+                  <div>
+                    <% unassigned = member["name"].nil? %>
+                    <% if unassigned %>
+                      <div class="p-6 border-3 border-dashed border-brand-gray/30 bg-brand-cream h-full">
+                        <div class="w-10 h-10 bg-brand-gray/10 flex items-center justify-center mb-4">
+                          <%= icon(member["icon"], class: "w-5 h-5 opacity-40") %>
+                        </div>
+                        <h3 class="heading heading-4"><%= member["role"] %></h3>
+                        <p class="text-brand-gray/50 text-sm italic">Unassigned</p>
+                      </div>
+                    <% else %>
+                      <div class="card" style="box-shadow: 5px 5px 0px var(--color-brand-red);">
+                        <div class="w-10 h-10 bg-brand-red/10 flex items-center justify-center mb-4">
+                          <%= icon(member["icon"], class: "w-5 h-5 text-brand-red") %>
+                        </div>
+                        <h3 class="heading heading-4"><%= member["role"] %></h3>
+                        <p class="text-sm"><%= member["name"] %></p>
+                      </div>
+                    <% end %>
                   </div>
                 <% end %>
               </div>
@@ -55,25 +80,29 @@
             <span class="badge badge-dark badge-sm">APPOINTED</span>
             <p class="text-sm mt-2">Voted on by the executive team. Applications are opened as needed.</p>
           </div>
-          <div class="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 gap-5 reveal stagger">
-            <% campus["appointed"].each do |member| %>
-              <div>
-                <% unassigned = member["name"].nil? %>
-                <% if unassigned %>
-                  <div class="p-6 border-3 border-dashed border-brand-gray/30 bg-brand-cream">
-                    <div class="w-10 h-10 bg-brand-gray/10 flex items-center justify-center mb-4">
-                      <%= icon(member["icon"], class: "w-5 h-5 opacity-40") %>
-                    </div>
-                    <h3 class="heading heading-4"><%= member["role"] %></h3>
-                    <p class="text-brand-gray/50 text-sm italic">Unassigned</p>
-                  </div>
-                <% else %>
-                  <div class="card" style="box-shadow: 5px 5px 0px var(--color-brand-red-300);">
-                    <div class="w-10 h-10 bg-brand-red/10 flex items-center justify-center mb-4">
-                      <%= icon(member["icon"], class: "w-5 h-5 text-brand-red") %>
-                    </div>
-                    <h3 class="heading heading-4"><%= member["role"] %></h3>
-                    <p class="text-sm"><%= member["name"] %></p>
+          <div class="flex flex-col gap-5 reveal stagger">
+            <% balanced_team_rows.call(campus["appointed"]).each do |row| %>
+              <div class="grid grid-cols-1 sm:grid-cols-2 <%= team_row_columns.fetch(row.length) %> gap-5">
+                <% row.each do |member| %>
+                  <div>
+                    <% unassigned = member["name"].nil? %>
+                    <% if unassigned %>
+                      <div class="p-6 border-3 border-dashed border-brand-gray/30 bg-brand-cream h-full">
+                        <div class="w-10 h-10 bg-brand-gray/10 flex items-center justify-center mb-4">
+                          <%= icon(member["icon"], class: "w-5 h-5 opacity-40") %>
+                        </div>
+                        <h3 class="heading heading-4"><%= member["role"] %></h3>
+                        <p class="text-brand-gray/50 text-sm italic">Unassigned</p>
+                      </div>
+                    <% else %>
+                      <div class="card" style="box-shadow: 5px 5px 0px var(--color-brand-red-300);">
+                        <div class="w-10 h-10 bg-brand-red/10 flex items-center justify-center mb-4">
+                          <%= icon(member["icon"], class: "w-5 h-5 text-brand-red") %>
+                        </div>
+                        <h3 class="heading heading-4"><%= member["role"] %></h3>
+                        <p class="text-sm"><%= member["name"] %></p>
+                      </div>
+                    <% end %>
                   </div>
                 <% end %>
               </div>

--- a/app/views/about/_team.html.erb
+++ b/app/views/about/_team.html.erb
@@ -19,7 +19,7 @@
   }
 %>
 
-<section id="team" data-controller="tabs">
+<section id="team" data-controller="tabs role-modal">
   <div class="container">
     <div class="mb-12 reveal">
       <h2 class="heading heading-2">Executive team.</h2>
@@ -51,22 +51,34 @@
                 <% row.each do |member| %>
                   <div>
                     <% unassigned = member["name"].nil? %>
+                    <% role_details = @team_roles.fetch(member["role"]) %>
                     <% if unassigned %>
-                      <div class="p-6 border-3 border-dashed border-brand-gray/30 bg-brand-cream h-full">
+                      <button type="button"
+                              data-action="role-modal#open"
+                              data-role="<%= member["role"] %>"
+                              data-responsibilities="<%= role_details["responsibilities"].to_json %>"
+                              data-note="<%= role_details["note"] %>"
+                              class="p-6 border-3 border-dashed border-brand-gray/30 bg-brand-cream h-full w-full text-left cursor-pointer transition-all duration-200 hover:-translate-y-1 hover:border-brand-black focus-visible:outline-3 focus-visible:outline-brand-red">
                         <div class="w-10 h-10 bg-brand-gray/10 flex items-center justify-center mb-4">
                           <%= icon(member["icon"], class: "w-5 h-5 opacity-40") %>
                         </div>
                         <h3 class="heading heading-4"><%= member["role"] %></h3>
                         <p class="text-brand-gray/50 text-sm italic">Unassigned</p>
-                      </div>
+                      </button>
                     <% else %>
-                      <div class="card" style="box-shadow: 5px 5px 0px var(--color-brand-red);">
+                      <button type="button"
+                              data-action="role-modal#open"
+                              data-role="<%= member["role"] %>"
+                              data-responsibilities="<%= role_details["responsibilities"].to_json %>"
+                              data-note="<%= role_details["note"] %>"
+                              class="card card-link w-full text-left cursor-pointer focus-visible:outline-3 focus-visible:outline-brand-red"
+                              style="box-shadow: 5px 5px 0px var(--color-brand-red);">
                         <div class="w-10 h-10 bg-brand-red/10 flex items-center justify-center mb-4">
                           <%= icon(member["icon"], class: "w-5 h-5 text-brand-red") %>
                         </div>
                         <h3 class="heading heading-4"><%= member["role"] %></h3>
                         <p class="text-sm"><%= member["name"] %></p>
-                      </div>
+                      </button>
                     <% end %>
                   </div>
                 <% end %>
@@ -86,22 +98,34 @@
                 <% row.each do |member| %>
                   <div>
                     <% unassigned = member["name"].nil? %>
+                    <% role_details = @team_roles.fetch(member["role"]) %>
                     <% if unassigned %>
-                      <div class="p-6 border-3 border-dashed border-brand-gray/30 bg-brand-cream h-full">
+                      <button type="button"
+                              data-action="role-modal#open"
+                              data-role="<%= member["role"] %>"
+                              data-responsibilities="<%= role_details["responsibilities"].to_json %>"
+                              data-note="<%= role_details["note"] %>"
+                              class="p-6 border-3 border-dashed border-brand-gray/30 bg-brand-cream h-full w-full text-left cursor-pointer transition-all duration-200 hover:-translate-y-1 hover:border-brand-black focus-visible:outline-3 focus-visible:outline-brand-red">
                         <div class="w-10 h-10 bg-brand-gray/10 flex items-center justify-center mb-4">
                           <%= icon(member["icon"], class: "w-5 h-5 opacity-40") %>
                         </div>
                         <h3 class="heading heading-4"><%= member["role"] %></h3>
                         <p class="text-brand-gray/50 text-sm italic">Unassigned</p>
-                      </div>
+                      </button>
                     <% else %>
-                      <div class="card" style="box-shadow: 5px 5px 0px var(--color-brand-red-300);">
+                      <button type="button"
+                              data-action="role-modal#open"
+                              data-role="<%= member["role"] %>"
+                              data-responsibilities="<%= role_details["responsibilities"].to_json %>"
+                              data-note="<%= role_details["note"] %>"
+                              class="card card-link w-full text-left cursor-pointer focus-visible:outline-3 focus-visible:outline-brand-red"
+                              style="box-shadow: 5px 5px 0px var(--color-brand-red-300);">
                         <div class="w-10 h-10 bg-brand-red/10 flex items-center justify-center mb-4">
                           <%= icon(member["icon"], class: "w-5 h-5 text-brand-red") %>
                         </div>
                         <h3 class="heading heading-4"><%= member["role"] %></h3>
                         <p class="text-sm"><%= member["name"] %></p>
-                      </div>
+                      </button>
                     <% end %>
                   </div>
                 <% end %>
@@ -111,5 +135,30 @@
         <% end %>
       </div>
     <% end %>
+  </div>
+
+  <div data-role-modal-target="backdrop"
+       data-action="click->role-modal#closeBackdrop"
+       role="presentation"
+       aria-hidden="true"
+       class="fixed inset-0 z-50 bg-brand-black/50 flex items-center justify-center px-6 opacity-0 pointer-events-none transition-opacity duration-300">
+    <div data-role-modal-target="panel"
+         role="dialog"
+         aria-modal="true"
+         aria-labelledby="role-modal-title"
+         class="relative bg-brand-bg border-3 border-brand-black shadow-[6px_6px_0px_var(--color-brand-red)] w-full max-w-lg p-8 scale-95 opacity-0 transition-all duration-300">
+      <button type="button"
+              data-role-modal-target="close"
+              data-action="role-modal#close"
+              aria-label="Close role responsibilities"
+              class="absolute top-4 right-4 w-10 h-10 inline-flex items-center justify-center border-3 border-brand-black bg-white text-brand-black cursor-pointer transition-colors hover:bg-brand-red hover:text-white focus-visible:outline-3 focus-visible:outline-brand-red">
+        <%= icon "x", class: "w-5 h-5" %>
+      </button>
+
+      <span class="badge badge-sm mb-5">ROLE</span>
+      <h2 id="role-modal-title" data-role-modal-target="title" class="heading heading-3 pr-12"></h2>
+      <ul data-role-modal-target="responsibilities" class="list-disc pl-5 space-y-3 mt-6"></ul>
+      <p data-role-modal-target="note" class="hidden mt-6 p-4 border-l-4 border-brand-red bg-brand-red/10 font-semibold text-brand-black"></p>
+    </div>
   </div>
 </section>

--- a/app/views/about/_team.html.erb
+++ b/app/views/about/_team.html.erb
@@ -61,8 +61,8 @@
                               data-member-name="Unassigned"
                               data-responsibilities="<%= role_details["responsibilities"].to_json %>"
                               data-history="<%= role_history.to_json %>"
-                              data-application-status="<%= role_details.dig("applications", "status") || "closed" %>"
-                              data-application-url="<%= role_details.dig("applications", "url") %>"
+                              data-application-status="<%= member.dig("applications", "status") || "closed" %>"
+                              data-application-url="<%= member.dig("applications", "url") %>"
                               class="p-6 border-3 border-dashed border-brand-gray/30 bg-brand-cream h-full w-full text-left cursor-pointer transition-transform duration-200 hover:-translate-y-1 focus-visible:outline-3 focus-visible:outline-brand-red">
                         <div class="w-10 h-10 bg-brand-gray/10 flex items-center justify-center mb-4">
                           <%= icon(member["icon"], class: "w-5 h-5 opacity-40") %>
@@ -78,8 +78,8 @@
                               data-member-name="<%= member["name"] %>"
                               data-responsibilities="<%= role_details["responsibilities"].to_json %>"
                               data-history="<%= role_history.to_json %>"
-                              data-application-status="<%= role_details.dig("applications", "status") || "closed" %>"
-                              data-application-url="<%= role_details.dig("applications", "url") %>"
+                              data-application-status="<%= member.dig("applications", "status") || "closed" %>"
+                              data-application-url="<%= member.dig("applications", "url") %>"
                               class="card card-link w-full text-left cursor-pointer focus-visible:outline-3 focus-visible:outline-brand-red"
                               style="box-shadow: 5px 5px 0px var(--color-brand-red);">
                         <div class="w-10 h-10 bg-brand-red/10 flex items-center justify-center mb-4">
@@ -117,8 +117,8 @@
                               data-member-name="Unassigned"
                               data-responsibilities="<%= role_details["responsibilities"].to_json %>"
                               data-history="<%= role_history.to_json %>"
-                              data-application-status="<%= role_details.dig("applications", "status") || "closed" %>"
-                              data-application-url="<%= role_details.dig("applications", "url") %>"
+                              data-application-status="<%= member.dig("applications", "status") || "closed" %>"
+                              data-application-url="<%= member.dig("applications", "url") %>"
                               class="p-6 border-3 border-dashed border-brand-gray/30 bg-brand-cream h-full w-full text-left cursor-pointer transition-transform duration-200 hover:-translate-y-1 focus-visible:outline-3 focus-visible:outline-brand-red">
                         <div class="w-10 h-10 bg-brand-gray/10 flex items-center justify-center mb-4">
                           <%= icon(member["icon"], class: "w-5 h-5 opacity-40") %>
@@ -134,8 +134,8 @@
                               data-member-name="<%= member["name"] %>"
                               data-responsibilities="<%= role_details["responsibilities"].to_json %>"
                               data-history="<%= role_history.to_json %>"
-                              data-application-status="<%= role_details.dig("applications", "status") || "closed" %>"
-                              data-application-url="<%= role_details.dig("applications", "url") %>"
+                              data-application-status="<%= member.dig("applications", "status") || "closed" %>"
+                              data-application-url="<%= member.dig("applications", "url") %>"
                               class="card card-link w-full text-left cursor-pointer focus-visible:outline-3 focus-visible:outline-brand-red"
                               style="box-shadow: 5px 5px 0px var(--color-brand-red-300);">
                         <div class="w-10 h-10 bg-brand-red/10 flex items-center justify-center mb-4">

--- a/app/views/about/_team.html.erb
+++ b/app/views/about/_team.html.erb
@@ -58,7 +58,9 @@
                               data-role="<%= member["role"] %>"
                               data-member-name="Unassigned"
                               data-responsibilities="<%= role_details["responsibilities"].to_json %>"
-                              class="p-6 border-3 border-dashed border-brand-gray/30 bg-brand-cream h-full w-full text-left cursor-pointer transition-all duration-200 hover:-translate-y-1 hover:border-brand-black focus-visible:outline-3 focus-visible:outline-brand-red">
+                              data-application-status="<%= role_details.dig("applications", "status") || "closed" %>"
+                              data-application-url="<%= role_details.dig("applications", "url") %>"
+                              class="p-6 border-3 border-dashed border-brand-gray/30 bg-brand-cream h-full w-full text-left cursor-pointer transition-transform duration-200 hover:-translate-y-1 focus-visible:outline-3 focus-visible:outline-brand-red">
                         <div class="w-10 h-10 bg-brand-gray/10 flex items-center justify-center mb-4">
                           <%= icon(member["icon"], class: "w-5 h-5 opacity-40") %>
                         </div>
@@ -105,7 +107,9 @@
                               data-role="<%= member["role"] %>"
                               data-member-name="Unassigned"
                               data-responsibilities="<%= role_details["responsibilities"].to_json %>"
-                              class="p-6 border-3 border-dashed border-brand-gray/30 bg-brand-cream h-full w-full text-left cursor-pointer transition-all duration-200 hover:-translate-y-1 hover:border-brand-black focus-visible:outline-3 focus-visible:outline-brand-red">
+                              data-application-status="<%= role_details.dig("applications", "status") || "closed" %>"
+                              data-application-url="<%= role_details.dig("applications", "url") %>"
+                              class="p-6 border-3 border-dashed border-brand-gray/30 bg-brand-cream h-full w-full text-left cursor-pointer transition-transform duration-200 hover:-translate-y-1 focus-visible:outline-3 focus-visible:outline-brand-red">
                         <div class="w-10 h-10 bg-brand-gray/10 flex items-center justify-center mb-4">
                           <%= icon(member["icon"], class: "w-5 h-5 opacity-40") %>
                         </div>
@@ -152,6 +156,19 @@
       <h2 id="role-modal-title" data-role-modal-target="title" class="heading heading-3"></h2>
       <p data-role-modal-target="member" class="font-semibold text-brand-red"></p>
       <ul data-role-modal-target="responsibilities" class="list-disc pl-5 space-y-3 mt-6"></ul>
+      <div data-role-modal-target="applicationActions" class="hidden mt-8 pt-6 border-t-3 border-brand-cream">
+        <a data-role-modal-target="applicationsOpen"
+           href="#"
+           class="hidden btn btn-primary w-full">
+          Apply now
+        </a>
+        <button data-role-modal-target="applicationsClosed"
+                type="button"
+                disabled
+                class="btn btn-secondary w-full opacity-50 disabled:cursor-not-allowed disabled:hover:translate-y-0">
+          Applications (closed)
+        </button>
+      </div>
     </div>
   </div>
 </section>

--- a/app/views/about/_team.html.erb
+++ b/app/views/about/_team.html.erb
@@ -165,7 +165,7 @@
         <button data-role-modal-target="applicationsClosed"
                 type="button"
                 disabled
-                class="btn btn-secondary w-full opacity-50 disabled:cursor-not-allowed disabled:hover:translate-y-0">
+                class="btn btn-secondary w-full opacity-50 disabled:cursor-not-allowed disabled:hover:translate-y-0 disabled:hover:shadow-none disabled:active:translate-y-0 disabled:active:shadow-none">
           Applications (closed)
         </button>
       </div>

--- a/app/views/about/_team.html.erb
+++ b/app/views/about/_team.html.erb
@@ -57,9 +57,12 @@
                       <button type="button"
                               data-action="role-modal#open"
                               data-role="<%= member["role"] %>"
+                              data-role-type="elected"
                               data-member-name="Unassigned"
                               data-responsibilities="<%= role_details["responsibilities"].to_json %>"
                               data-history="<%= role_history.to_json %>"
+                              data-application-status="<%= role_details.dig("applications", "status") || "closed" %>"
+                              data-application-url="<%= role_details.dig("applications", "url") %>"
                               class="p-6 border-3 border-dashed border-brand-gray/30 bg-brand-cream h-full w-full text-left cursor-pointer transition-transform duration-200 hover:-translate-y-1 focus-visible:outline-3 focus-visible:outline-brand-red">
                         <div class="w-10 h-10 bg-brand-gray/10 flex items-center justify-center mb-4">
                           <%= icon(member["icon"], class: "w-5 h-5 opacity-40") %>
@@ -71,9 +74,12 @@
                       <button type="button"
                               data-action="role-modal#open"
                               data-role="<%= member["role"] %>"
+                              data-role-type="elected"
                               data-member-name="<%= member["name"] %>"
                               data-responsibilities="<%= role_details["responsibilities"].to_json %>"
                               data-history="<%= role_history.to_json %>"
+                              data-application-status="<%= role_details.dig("applications", "status") || "closed" %>"
+                              data-application-url="<%= role_details.dig("applications", "url") %>"
                               class="card card-link w-full text-left cursor-pointer focus-visible:outline-3 focus-visible:outline-brand-red"
                               style="box-shadow: 5px 5px 0px var(--color-brand-red);">
                         <div class="w-10 h-10 bg-brand-red/10 flex items-center justify-center mb-4">
@@ -107,9 +113,12 @@
                       <button type="button"
                               data-action="role-modal#open"
                               data-role="<%= member["role"] %>"
+                              data-role-type="appointed"
                               data-member-name="Unassigned"
                               data-responsibilities="<%= role_details["responsibilities"].to_json %>"
                               data-history="<%= role_history.to_json %>"
+                              data-application-status="<%= role_details.dig("applications", "status") || "closed" %>"
+                              data-application-url="<%= role_details.dig("applications", "url") %>"
                               class="p-6 border-3 border-dashed border-brand-gray/30 bg-brand-cream h-full w-full text-left cursor-pointer transition-transform duration-200 hover:-translate-y-1 focus-visible:outline-3 focus-visible:outline-brand-red">
                         <div class="w-10 h-10 bg-brand-gray/10 flex items-center justify-center mb-4">
                           <%= icon(member["icon"], class: "w-5 h-5 opacity-40") %>
@@ -121,9 +130,12 @@
                       <button type="button"
                               data-action="role-modal#open"
                               data-role="<%= member["role"] %>"
+                              data-role-type="appointed"
                               data-member-name="<%= member["name"] %>"
                               data-responsibilities="<%= role_details["responsibilities"].to_json %>"
                               data-history="<%= role_history.to_json %>"
+                              data-application-status="<%= role_details.dig("applications", "status") || "closed" %>"
+                              data-application-url="<%= role_details.dig("applications", "url") %>"
                               class="card card-link w-full text-left cursor-pointer focus-visible:outline-3 focus-visible:outline-brand-red"
                               style="box-shadow: 5px 5px 0px var(--color-brand-red-300);">
                         <div class="w-10 h-10 bg-brand-red/10 flex items-center justify-center mb-4">
@@ -159,13 +171,7 @@
       <p data-role-modal-target="member" class="font-semibold text-brand-red"></p>
       <ul data-role-modal-target="responsibilities" class="list-disc pl-5 space-y-3 mt-6"></ul>
 
-      <div data-role-modal-target="applicationActions" class="hidden mt-8 pt-6 border-t-3 border-brand-cream">
-        <button type="button"
-                disabled
-                class="btn btn-disabled w-full">
-          Applications (closed)
-        </button>
-      </div>
+      <div data-role-modal-target="applicationActions" class="hidden mt-8 pt-6 border-t-3 border-brand-cream"></div>
 
       <div class="mt-8 pt-6 border-t-3 border-brand-cream">
         <h3 class="heading heading-5">Role history</h3>

--- a/app/views/about/_team.html.erb
+++ b/app/views/about/_team.html.erb
@@ -56,8 +56,8 @@
                       <button type="button"
                               data-action="role-modal#open"
                               data-role="<%= member["role"] %>"
+                              data-member-name="Unassigned"
                               data-responsibilities="<%= role_details["responsibilities"].to_json %>"
-                              data-note="<%= role_details["note"] %>"
                               class="p-6 border-3 border-dashed border-brand-gray/30 bg-brand-cream h-full w-full text-left cursor-pointer transition-all duration-200 hover:-translate-y-1 hover:border-brand-black focus-visible:outline-3 focus-visible:outline-brand-red">
                         <div class="w-10 h-10 bg-brand-gray/10 flex items-center justify-center mb-4">
                           <%= icon(member["icon"], class: "w-5 h-5 opacity-40") %>
@@ -69,8 +69,8 @@
                       <button type="button"
                               data-action="role-modal#open"
                               data-role="<%= member["role"] %>"
+                              data-member-name="<%= member["name"] %>"
                               data-responsibilities="<%= role_details["responsibilities"].to_json %>"
-                              data-note="<%= role_details["note"] %>"
                               class="card card-link w-full text-left cursor-pointer focus-visible:outline-3 focus-visible:outline-brand-red"
                               style="box-shadow: 5px 5px 0px var(--color-brand-red);">
                         <div class="w-10 h-10 bg-brand-red/10 flex items-center justify-center mb-4">
@@ -103,8 +103,8 @@
                       <button type="button"
                               data-action="role-modal#open"
                               data-role="<%= member["role"] %>"
+                              data-member-name="Unassigned"
                               data-responsibilities="<%= role_details["responsibilities"].to_json %>"
-                              data-note="<%= role_details["note"] %>"
                               class="p-6 border-3 border-dashed border-brand-gray/30 bg-brand-cream h-full w-full text-left cursor-pointer transition-all duration-200 hover:-translate-y-1 hover:border-brand-black focus-visible:outline-3 focus-visible:outline-brand-red">
                         <div class="w-10 h-10 bg-brand-gray/10 flex items-center justify-center mb-4">
                           <%= icon(member["icon"], class: "w-5 h-5 opacity-40") %>
@@ -116,8 +116,8 @@
                       <button type="button"
                               data-action="role-modal#open"
                               data-role="<%= member["role"] %>"
+                              data-member-name="<%= member["name"] %>"
                               data-responsibilities="<%= role_details["responsibilities"].to_json %>"
-                              data-note="<%= role_details["note"] %>"
                               class="card card-link w-full text-left cursor-pointer focus-visible:outline-3 focus-visible:outline-brand-red"
                               style="box-shadow: 5px 5px 0px var(--color-brand-red-300);">
                         <div class="w-10 h-10 bg-brand-red/10 flex items-center justify-center mb-4">
@@ -146,19 +146,12 @@
          role="dialog"
          aria-modal="true"
          aria-labelledby="role-modal-title"
-         class="relative bg-brand-bg border-3 border-brand-black shadow-[6px_6px_0px_var(--color-brand-red)] w-full max-w-lg p-8 scale-95 opacity-0 transition-all duration-300">
-      <button type="button"
-              data-role-modal-target="close"
-              data-action="role-modal#close"
-              aria-label="Close role responsibilities"
-              class="absolute top-4 right-4 w-10 h-10 inline-flex items-center justify-center border-3 border-brand-black bg-white text-brand-black cursor-pointer transition-colors hover:bg-brand-red hover:text-white focus-visible:outline-3 focus-visible:outline-brand-red">
-        <%= icon "x", class: "w-5 h-5" %>
-      </button>
-
+         tabindex="-1"
+         class="relative bg-brand-bg border-3 border-brand-black shadow-[6px_6px_0px_var(--color-brand-red)] w-full max-w-lg p-8 scale-95 opacity-0 transition-all duration-300 focus:outline-none">
       <span class="badge badge-sm mb-5">ROLE</span>
-      <h2 id="role-modal-title" data-role-modal-target="title" class="heading heading-3 pr-12"></h2>
+      <h2 id="role-modal-title" data-role-modal-target="title" class="heading heading-3"></h2>
+      <p data-role-modal-target="member" class="font-semibold text-brand-red"></p>
       <ul data-role-modal-target="responsibilities" class="list-disc pl-5 space-y-3 mt-6"></ul>
-      <p data-role-modal-target="note" class="hidden mt-6 p-4 border-l-4 border-brand-red bg-brand-red/10 font-semibold text-brand-black"></p>
     </div>
   </div>
 </section>

--- a/app/views/about/_team.html.erb
+++ b/app/views/about/_team.html.erb
@@ -52,14 +52,14 @@
                   <div>
                     <% unassigned = member["name"].nil? %>
                     <% role_details = @team_roles.fetch(member["role"]) %>
+                    <% role_history = member["history"] || [{ "name" => member["name"] || "Unassigned", "period" => "Present" }] %>
                     <% if unassigned %>
                       <button type="button"
                               data-action="role-modal#open"
                               data-role="<%= member["role"] %>"
                               data-member-name="Unassigned"
                               data-responsibilities="<%= role_details["responsibilities"].to_json %>"
-                              data-application-status="<%= role_details.dig("applications", "status") || "closed" %>"
-                              data-application-url="<%= role_details.dig("applications", "url") %>"
+                              data-history="<%= role_history.to_json %>"
                               class="p-6 border-3 border-dashed border-brand-gray/30 bg-brand-cream h-full w-full text-left cursor-pointer transition-transform duration-200 hover:-translate-y-1 focus-visible:outline-3 focus-visible:outline-brand-red">
                         <div class="w-10 h-10 bg-brand-gray/10 flex items-center justify-center mb-4">
                           <%= icon(member["icon"], class: "w-5 h-5 opacity-40") %>
@@ -73,6 +73,7 @@
                               data-role="<%= member["role"] %>"
                               data-member-name="<%= member["name"] %>"
                               data-responsibilities="<%= role_details["responsibilities"].to_json %>"
+                              data-history="<%= role_history.to_json %>"
                               class="card card-link w-full text-left cursor-pointer focus-visible:outline-3 focus-visible:outline-brand-red"
                               style="box-shadow: 5px 5px 0px var(--color-brand-red);">
                         <div class="w-10 h-10 bg-brand-red/10 flex items-center justify-center mb-4">
@@ -101,14 +102,14 @@
                   <div>
                     <% unassigned = member["name"].nil? %>
                     <% role_details = @team_roles.fetch(member["role"]) %>
+                    <% role_history = member["history"] || [{ "name" => member["name"] || "Unassigned", "period" => "Present" }] %>
                     <% if unassigned %>
                       <button type="button"
                               data-action="role-modal#open"
                               data-role="<%= member["role"] %>"
                               data-member-name="Unassigned"
                               data-responsibilities="<%= role_details["responsibilities"].to_json %>"
-                              data-application-status="<%= role_details.dig("applications", "status") || "closed" %>"
-                              data-application-url="<%= role_details.dig("applications", "url") %>"
+                              data-history="<%= role_history.to_json %>"
                               class="p-6 border-3 border-dashed border-brand-gray/30 bg-brand-cream h-full w-full text-left cursor-pointer transition-transform duration-200 hover:-translate-y-1 focus-visible:outline-3 focus-visible:outline-brand-red">
                         <div class="w-10 h-10 bg-brand-gray/10 flex items-center justify-center mb-4">
                           <%= icon(member["icon"], class: "w-5 h-5 opacity-40") %>
@@ -122,6 +123,7 @@
                               data-role="<%= member["role"] %>"
                               data-member-name="<%= member["name"] %>"
                               data-responsibilities="<%= role_details["responsibilities"].to_json %>"
+                              data-history="<%= role_history.to_json %>"
                               class="card card-link w-full text-left cursor-pointer focus-visible:outline-3 focus-visible:outline-brand-red"
                               style="box-shadow: 5px 5px 0px var(--color-brand-red-300);">
                         <div class="w-10 h-10 bg-brand-red/10 flex items-center justify-center mb-4">
@@ -151,19 +153,19 @@
          aria-modal="true"
          aria-labelledby="role-modal-title"
          tabindex="-1"
-         class="relative bg-brand-bg border-3 border-brand-black shadow-[6px_6px_0px_var(--color-brand-red)] w-full max-w-lg p-8 scale-95 opacity-0 transition-all duration-300 focus:outline-none">
+         class="relative bg-brand-bg border-3 border-brand-black shadow-[6px_6px_0px_var(--color-brand-red)] w-full max-w-lg max-h-[calc(100vh-3rem)] overflow-y-auto p-8 scale-95 opacity-0 transition-all duration-300 focus:outline-none">
       <span class="badge badge-sm mb-5">ROLE</span>
       <h2 id="role-modal-title" data-role-modal-target="title" class="heading heading-3"></h2>
       <p data-role-modal-target="member" class="font-semibold text-brand-red"></p>
       <ul data-role-modal-target="responsibilities" class="list-disc pl-5 space-y-3 mt-6"></ul>
+
+      <div class="mt-8 pt-6 border-t-3 border-brand-cream">
+        <h3 class="heading heading-5">Role history</h3>
+        <ol data-role-modal-target="timeline" class="ml-2 border-l-2 border-brand-gray/30"></ol>
+      </div>
+
       <div data-role-modal-target="applicationActions" class="hidden mt-8 pt-6 border-t-3 border-brand-cream">
-        <a data-role-modal-target="applicationsOpen"
-           href="#"
-           class="hidden btn btn-primary w-full">
-          Apply now
-        </a>
-        <button data-role-modal-target="applicationsClosed"
-                type="button"
+        <button type="button"
                 disabled
                 class="btn btn-disabled w-full">
           Applications (closed)

--- a/config/team.yml
+++ b/config/team.yml
@@ -8,7 +8,7 @@ campuses:
         name: Tylar Pinniger
         icon: shield
       - role: Treasurer
-        name: ~
+        name: Novak Bigic
         icon: wallet
       - role: Secretary
         name: Julio Medeiros

--- a/config/team.yml
+++ b/config/team.yml
@@ -4,22 +4,52 @@ campuses:
       - role: President
         name: William Jackson
         icon: crown
+        history:
+          - name: Owen Richardson
+            period: Mar 2025 - Jun 2026
+          - name: William Jackson
+            period: Jul 2026 - Present
       - role: Vice President
         name: Tylar Pinniger
         icon: shield
+        history:
+          - name: Michael Geurts
+            period: Sep 2025 - Jan 2026
+          - name: Tylar Pinniger
+            period: Feb 2026 - Present
       - role: Treasurer
         name: Novak Bigic
         icon: wallet
+        history:
+          - name: William Jackson
+            period: Mar 2025 - Jun 2026
+          - name: Novak Bigic
+            period: Jul 2026 - Present
       - role: Secretary
         name: Julio Medeiros
         icon: file-text
+        history:
+          - name: Zain Abrahams
+            period: Mar 2025 - Jun 2026
+          - name: Julio Medeiros
+            period: Jul 2026 - Present
     appointed:
       - role: Events Co-ordinator
         name: Tylar Pinniger
         icon: calendar
+        history:
+          - name: Michael Geurts
+            period: Mar 2025 - Aug 2025
+          - name: Tylar Pinniger
+            period: Sep 2025 - Present
       - role: Social Media Manager
         name: ~
         icon: megaphone
+        history:
+          - name: Zarli Wilcock
+            period: Mar 2025 - Aug 2025
+          - name: Unassigned
+            period: Sep 2025 - Present
   - name: Brisbane
     elected:
       - role: President
@@ -78,9 +108,6 @@ roles:
       - Prepare event plans and coordinate volunteers.
       - Run events and complete required risk or Guild paperwork.
   Social Media Manager:
-    applications:
-      status: closed
-      url: ~
     responsibilities:
       - Maintain the club’s content calendar.
       - Create and publish posts across club platforms.

--- a/config/team.yml
+++ b/config/team.yml
@@ -44,3 +44,48 @@ campuses:
       - role: Industry Liaison
         name: Johnroy Real
         icon: briefcase
+
+roles:
+  President:
+    responsibilities:
+      - Chair executive meetings and general meetings.
+      - Set committee priorities and assign work.
+      - Represent the club to Griffith, the Guild, and external organisations.
+      - Ensure the committee follows the constitution and its decisions.
+  Vice President:
+    note: The Vice President may act independently and does not require the President’s approval for routine club work.
+    responsibilities:
+      - Lead club projects without requiring the President’s approval.
+      - Chair meetings and represent the club when needed.
+      - Coordinate committee members and follow up unfinished work.
+      - Perform the President’s duties when they are unavailable.
+  Treasurer:
+    responsibilities:
+      - Maintain records of all money received and spent.
+      - Prepare and monitor the club’s budget.
+      - Process purchases, reimbursements, and invoices.
+      - Present financial reports to the committee, members, and Guild.
+  Secretary:
+    responsibilities:
+      - Prepare and distribute meeting agendas.
+      - Record and distribute meeting minutes.
+      - Maintain official club records and correspondence.
+      - Organise notices and documents for AGMs and general meetings.
+  Events Co-ordinator:
+    responsibilities:
+      - Plan the club’s event calendar.
+      - Book venues, equipment, catering, and other event requirements.
+      - Prepare event plans and coordinate volunteers.
+      - Run events and complete required risk or Guild paperwork.
+  Social Media Manager:
+    responsibilities:
+      - Maintain the club’s content calendar.
+      - Create and publish posts across club platforms.
+      - Promote events, opportunities, sponsors, and announcements.
+      - Photograph or collect content from club activities.
+  Industry Liaison:
+    responsibilities:
+      - Contact companies and professional organisations.
+      - Arrange industry speakers, workshops, and networking opportunities.
+      - Maintain records of industry contacts and conversations.
+      - Coordinate sponsor commitments with the committee.

--- a/config/team.yml
+++ b/config/team.yml
@@ -2,16 +2,16 @@ campuses:
   - name: Gold Coast
     elected:
       - role: President
-        name: Owen Richardson
+        name: William Jackson
         icon: crown
       - role: Vice President
         name: Tylar Pinniger
         icon: shield
       - role: Treasurer
-        name: William Jackson
+        name: ~
         icon: wallet
       - role: Secretary
-        name: Zain Abrahams
+        name: Julio Medeiros
         icon: file-text
     appointed:
       - role: Events Co-ordinator
@@ -20,10 +20,6 @@ campuses:
       - role: Social Media Manager
         name: ~
         icon: megaphone
-      - role: Industry Liaison
-        name: Julio Medeiros
-        icon: briefcase
-
   - name: Brisbane
     elected:
       - role: President

--- a/config/team.yml
+++ b/config/team.yml
@@ -78,6 +78,9 @@ roles:
       - Prepare event plans and coordinate volunteers.
       - Run events and complete required risk or Guild paperwork.
   Social Media Manager:
+    applications:
+      status: closed
+      url: ~
     responsibilities:
       - Maintain the club’s content calendar.
       - Create and publish posts across club platforms.

--- a/config/team.yml
+++ b/config/team.yml
@@ -9,6 +9,7 @@ campuses:
             period: Mar 2025 - Jun 2026
           - name: William Jackson
             period: Jul 2026 - Present
+            acting: true
       - role: Vice President
         name: Tylar Pinniger
         icon: shield
@@ -25,6 +26,7 @@ campuses:
             period: Mar 2025 - Jun 2026
           - name: Novak Bigic
             period: Jul 2026 - Present
+            acting: true
       - role: Secretary
         name: Julio Medeiros
         icon: file-text
@@ -33,6 +35,7 @@ campuses:
             period: Mar 2025 - Jun 2026
           - name: Julio Medeiros
             period: Jul 2026 - Present
+            acting: true
     appointed:
       - role: Events Co-ordinator
         name: Tylar Pinniger

--- a/config/team.yml
+++ b/config/team.yml
@@ -105,27 +105,18 @@ roles:
       - Maintain official club records and correspondence.
       - Organise notices and documents for AGMs and general meetings.
   Events Co-ordinator:
-    applications:
-      status: closed
-      url: ~
     responsibilities:
       - Plan the club’s event calendar.
       - Book venues, equipment, catering, and other event requirements.
       - Prepare event plans and coordinate volunteers.
       - Run events and complete required risk or Guild paperwork.
   Social Media Manager:
-    applications:
-      status: closed
-      url: ~
     responsibilities:
       - Maintain the club’s content calendar.
       - Create and publish posts across club platforms.
       - Promote events, opportunities, sponsors, and announcements.
       - Photograph or collect content from club activities.
   Industry Liaison:
-    applications:
-      status: closed
-      url: ~
     responsibilities:
       - Contact companies and professional organisations.
       - Arrange industry speakers, workshops, and networking opportunities.

--- a/config/team.yml
+++ b/config/team.yml
@@ -105,18 +105,27 @@ roles:
       - Maintain official club records and correspondence.
       - Organise notices and documents for AGMs and general meetings.
   Events Co-ordinator:
+    applications:
+      status: closed
+      url: ~
     responsibilities:
       - Plan the club’s event calendar.
       - Book venues, equipment, catering, and other event requirements.
       - Prepare event plans and coordinate volunteers.
       - Run events and complete required risk or Guild paperwork.
   Social Media Manager:
+    applications:
+      status: closed
+      url: ~
     responsibilities:
       - Maintain the club’s content calendar.
       - Create and publish posts across club platforms.
       - Promote events, opportunities, sponsors, and announcements.
       - Photograph or collect content from club activities.
   Industry Liaison:
+    applications:
+      status: closed
+      url: ~
     responsibilities:
       - Contact companies and professional organisations.
       - Arrange industry speakers, workshops, and networking opportunities.

--- a/config/team.yml
+++ b/config/team.yml
@@ -53,8 +53,8 @@ roles:
       - Represent the club to Griffith, the Guild, and external organisations.
       - Ensure the committee follows the constitution and its decisions.
   Vice President:
-    note: The Vice President may act independently and does not require the President’s approval for routine club work.
     responsibilities:
+      - The Vice President may act independently and does not require the President’s approval for routine club work.
       - Lead club projects without requiring the President’s approval.
       - Chair meetings and represent the club when needed.
       - Coordinate committee members and follow up unfinished work.


### PR DESCRIPTION
## Summary

- make every team card clickable and keyboard accessible
- show the current officeholder and concise responsibilities in a modal
- document the Vice President's authority to act independently on routine club work
- add reverse-chronological role timelines with term durations
- mark current acting Gold Coast officers within timelines
- distinguish unassigned periods with muted timeline styling
- scope application status to each campus position independently
- close modals by clicking outside or pressing Escape

## Application visibility

- appointed and closed: show Applications closed
- elected and closed: hide the application control
- any individual position configured open: show an active Applications open form link

## Depends on

- #70

## Verification

- verified modal content, focus restoration, click-outside closing, and Escape closing
- verified timeline order, durations, acting badges, vacancy styling, and application visibility
- verified one campus position can open applications without affecting the same role on another campus
- passed preview deployment and repository checks