### PR TITLE
Configure Neon databases for deployed environments

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,9 @@
+# PostgreSQL is only used by production and VPS preview processes.
+# Use a pooled Neon URL for application traffic.
+DATABASE_URL=''
+
+# Use the matching direct (non-pooler) Neon URL for migrations and seeds.
+DIRECT_DATABASE_URL=''
+
+# Required by db/seeds.rb when seeding a production-mode database.
+ADMIN_PASSWORD=''

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -20,12 +20,25 @@ jobs:
             ssh -o StrictHostKeyChecking=no -o ConnectTimeout=30 -i /tmp/deploy_key root@${{ secrets.VPS_HOST }} '
               export PATH="$HOME/.rbenv/bin:$HOME/.rbenv/shims:$PATH"
               cd ~/griffith-ict-web
+              if [ -f storage/production.sqlite3 ]; then
+                mkdir -p ~/griffith-ict-backups
+                cp -n storage/production.sqlite3 ~/griffith-ict-backups/production-before-postgresql.sqlite3
+                chmod 600 ~/griffith-ict-backups/production-before-postgresql.sqlite3
+              fi
               git pull
               bundle install
               set -a && source .env && set +a
-              RAILS_ENV=production bin/rails db:migrate
-              RAILS_ENV=production bin/rails db:seed
+              : "${DATABASE_URL:?DATABASE_URL must be set in .env}"
+              : "${DIRECT_DATABASE_URL:?DIRECT_DATABASE_URL must be set in .env}"
+              DATABASE_URL="$DIRECT_DATABASE_URL" RAILS_ENV=production bin/rails db:migrate
+              DATABASE_URL="$DIRECT_DATABASE_URL" RAILS_ENV=production bin/rails db:seed
               RAILS_ENV=production bin/rails assets:precompile
+              mkdir -p /etc/systemd/system/griffith-web.service.d
+              cat > /etc/systemd/system/griffith-web.service.d/environment.conf <<EOF
+            [Service]
+            EnvironmentFile=/root/griffith-ict-web/.env
+            EOF
+              systemctl daemon-reload
               systemctl restart griffith-web
             '
             rm -f /tmp/deploy_key

--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -89,8 +89,10 @@ jobs:
               # Install dependencies and build
               bundle install --jobs 4
               set -a && source /opt/previews/.env && set +a
-              RAILS_ENV=production bin/rails db:prepare
-              RAILS_ENV=production bin/rails db:seed
+              : "\${DATABASE_URL:?DATABASE_URL must be set in /opt/previews/.env}"
+              : "\${DIRECT_DATABASE_URL:?DIRECT_DATABASE_URL must be set in /opt/previews/.env}"
+              DATABASE_URL="\$DIRECT_DATABASE_URL" RAILS_ENV=production bin/rails db:migrate
+              DATABASE_URL="\$DIRECT_DATABASE_URL" RAILS_ENV=production bin/rails db:seed
               RAILS_ENV=production bin/rails assets:precompile
 
               # Write systemd override with PORT and SECRET_KEY_BASE

--- a/Gemfile
+++ b/Gemfile
@@ -4,8 +4,8 @@ source "https://rubygems.org"
 gem "rails", "~> 8.1.2"
 # The modern asset pipeline for Rails [https://github.com/rails/propshaft]
 gem "propshaft"
-# Use sqlite3 as the database for Active Record
-gem "sqlite3", ">= 2.1"
+# Use PostgreSQL for production and preview deployments
+gem "pg", "~> 1.6"
 # Use the Puma web server [https://github.com/puma/puma]
 gem "puma", ">= 5.0"
 # Use Active Model has_secure_password [https://guides.rubyonrails.org/active_model_basics.html#securepassword]
@@ -22,6 +22,9 @@ gem "rails_icons"
 gem "tzinfo-data", platforms: %i[ windows jruby ]
 
 group :development, :test do
+  # Keep local development and automated tests self-contained
+  gem "sqlite3", ">= 2.1"
+
   # See https://guides.rubyonrails.org/debugging_rails_applications.html#debugging-with-the-debug-gem
   gem "debug", platforms: %i[ mri windows ], require: "debug/prelude"
   gem "dotenv-rails"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -151,6 +151,13 @@ GEM
       racc (~> 1.4)
     nokogiri (1.19.2-x86_64-linux-musl)
       racc (~> 1.4)
+    pg (1.6.3)
+    pg (1.6.3-aarch64-linux)
+    pg (1.6.3-aarch64-linux-musl)
+    pg (1.6.3-arm64-darwin)
+    pg (1.6.3-x86_64-darwin)
+    pg (1.6.3-x86_64-linux)
+    pg (1.6.3-x86_64-linux-musl)
     pp (0.6.3)
       prettyprint
     prettyprint (0.2.0)
@@ -267,6 +274,7 @@ DEPENDENCIES
   debug
   dotenv-rails
   importmap-rails (~> 2.2)
+  pg (~> 1.6)
   propshaft
   puma (>= 5.0)
   rails (~> 8.1.2)
@@ -330,6 +338,13 @@ CHECKSUMS
   nokogiri (1.19.2-x86_64-darwin) sha256=7d9af11fda72dfaa2961d8c4d5380ca0b51bc389dc5f8d4b859b9644f195e7a4
   nokogiri (1.19.2-x86_64-linux-gnu) sha256=fa8feca882b73e871a9845f3817a72e9734c8e974bdc4fbad6e4bc6e8076b94f
   nokogiri (1.19.2-x86_64-linux-musl) sha256=93128448e61a9383a30baef041bf1f5817e22f297a1d400521e90294445069a8
+  pg (1.6.3) sha256=1388d0563e13d2758c1089e35e973a3249e955c659592d10e5b77c468f628a99
+  pg (1.6.3-aarch64-linux) sha256=0698ad563e02383c27510b76bf7d4cd2de19cd1d16a5013f375dd473e4be72ea
+  pg (1.6.3-aarch64-linux-musl) sha256=06a75f4ea04b05140146f2a10550b8e0d9f006a79cdaf8b5b130cde40e3ecc2c
+  pg (1.6.3-arm64-darwin) sha256=7240330b572e6355d7c75a7de535edb5dfcbd6295d9c7777df4d9dddfb8c0e5f
+  pg (1.6.3-x86_64-darwin) sha256=ee2e04a17c0627225054ffeb43e31a95be9d7e93abda2737ea3ce4a62f2729d6
+  pg (1.6.3-x86_64-linux) sha256=5d9e188c8f7a0295d162b7b88a768d8452a899977d44f3274d1946d67920ae8d
+  pg (1.6.3-x86_64-linux-musl) sha256=9c9c90d98c72f78eb04c0f55e9618fe55d1512128e411035fe229ff427864009
   pp (0.6.3) sha256=2951d514450b93ccfeb1df7d021cae0da16e0a7f95ee1e2273719669d0ab9df6
   prettyprint (0.2.0) sha256=2bc9e15581a94742064a3cc8b0fb9d45aae3d03a1baa6ef80922627a0766f193
   prism (1.9.0) sha256=7b530c6a9f92c24300014919c9dcbc055bf4cdf51ec30aed099b06cd6674ef85

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ https://griffithict.club/
 | Styling   | Tailwind CSS                        |
 | UI        | ViewComponent, Stimulus, Lucide     |
 | Assets    | Propshaft, Importmap                |
-| Database  | SQLite 3                            |
+| Database  | SQLite 3 (local/test), PostgreSQL (deployed) |
 | Server    | Puma                                |
 | Deploy    | GitHub Actions → VPS via SSH        |
 
@@ -71,7 +71,32 @@ Site content is driven by YAML files in `config/`:
 - **`sponsors.yml`** — Current sponsors
 - **`sponsorship_tiers.yml`** — Sponsorship tier names, prices, and perks
 
+### Databases
+
+Local development and automated tests use SQLite, so no database service or
+credentials are needed to run the app locally.
+
+Production and VPS previews use Neon PostgreSQL. Each deployed environment
+requires two variables in its protected `.env` file:
+
+- `DATABASE_URL` — the pooled Neon connection string used by Puma.
+- `DIRECT_DATABASE_URL` — the matching direct connection string used only for
+  migrations and seeds.
+
+Do not commit either value. Copy `.env.example` only when configuring a deployed
+environment. Store production values in `~/griffith-ict-web/.env` and preview
+values in `/opt/previews/.env`, keep the values shell-quoted because the URLs
+contain `&`, then restrict each file with `chmod 600`.
+
+All preview sites share the preview database. Migrations deployed to previews
+must therefore remain backward-compatible with other preview branches, and
+preview teardown never reverses database migrations.
+
 ## Deployment
 
 Merging to `master` triggers an automatic deploy via GitHub Actions.
 
+Before the first PostgreSQL deploy, back up `storage/production.sqlite3`, rotate
+the Neon owner passwords, and place the new pooled and direct URLs in the VPS
+environment files. The VPS connects outbound to Neon; it does not run a local
+PostgreSQL server.

--- a/config/database.yml
+++ b/config/database.yml
@@ -1,31 +1,23 @@
-# SQLite. Versions 3.8.0 and up are supported.
-#   gem install sqlite3
-#
-#   Ensure the SQLite 3 gem is defined in your Gemfile
-#   gem "sqlite3"
-#
 default: &default
-  adapter: sqlite3
-  max_connections: <%= ENV.fetch("RAILS_MAX_THREADS") { 5 } %>
-  timeout: 5000
+  pool: <%= ENV.fetch("RAILS_MAX_THREADS") { 5 } %>
 
 development:
   <<: *default
+  adapter: sqlite3
   database: storage/development.sqlite3
+  timeout: 5000
 
 # Warning: The database defined as "test" will be erased and
 # re-generated from your development database when you run "rake".
 # Do not set this db to the same as development or production.
 test:
   <<: *default
+  adapter: sqlite3
   database: storage/test.sqlite3
+  timeout: 5000
 
-# SQLite3 write its data on the local filesystem, as such it requires
-# persistent disks. If you are deploying to a managed service, you should
-# make sure it provides disk persistence, as many don't.
-#
-# Similarly, if you deploy your application as a Docker container, you must
-# ensure the database is located in a persisted volume.
 production:
   <<: *default
-  database: storage/production.sqlite3
+  adapter: postgresql
+  encoding: unicode
+  url: <%= ENV["DATABASE_URL"] %>

--- a/config/initializers/database_url.rb
+++ b/config/initializers/database_url.rb
@@ -1,0 +1,3 @@
+if Rails.env.production? && ENV["DATABASE_URL"].blank?
+  raise "DATABASE_URL must be set in production"
+end

--- a/script/vps-preview-setup.sh
+++ b/script/vps-preview-setup.sh
@@ -4,6 +4,11 @@ set -euo pipefail
 echo "==> Creating preview directory"
 mkdir -p /opt/previews
 
+if [ -f /opt/previews/.env ]; then
+  chmod 600 /opt/previews/.env
+  echo "    Protected existing /opt/previews/.env"
+fi
+
 echo "==> Generating shared SECRET_KEY_BASE"
 if [ ! -f /opt/previews/.secret_key_base ]; then
   openssl rand -hex 64 > /opt/previews/.secret_key_base
@@ -52,5 +57,11 @@ echo "3. Ensure nginx includes conf.d/*.conf in its http block:"
 echo "   include /etc/nginx/conf.d/*.conf;"
 echo ""
 echo "4. Create a 'preview' label in the GitHub repository."
+echo ""
+echo "5. Create /opt/previews/.env with shell-quoted values for:"
+echo "   DATABASE_URL (pooled Neon URL)"
+echo "   DIRECT_DATABASE_URL (matching direct Neon URL)"
+echo "   ADMIN_PASSWORD"
+echo "   Then run: chmod 600 /opt/previews/.env"
 echo ""
 echo "Setup complete."

--- a/test/fixtures/invites.yml
+++ b/test/fixtures/invites.yml
@@ -3,7 +3,7 @@
 one:
   email: MyString
   role: 1
-  token: MyString
+  token: invite-token-one
   expires_at: 2026-04-04 14:00:25
   accepted_at: 2026-04-04 14:00:25
   invited_by: one
@@ -11,7 +11,7 @@ one:
 two:
   email: MyString
   role: 1
-  token: MyString
+  token: invite-token-two
   expires_at: 2026-04-04 14:00:25
   accepted_at: 2026-04-04 14:00:25
   invited_by: two


### PR DESCRIPTION
## Summary
- keep local development and tests on SQLite
- use Neon PostgreSQL for production and previews
- use direct connections for migrations and pooled connections at runtime
- back up the existing production SQLite file during cutover

## Verification
- bin/ci
- production adapter boot check
- workflow YAML and shell validation
- credential audit