### PR TITLE
Add Lookbook for component previews

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -9,6 +9,7 @@ gem "bcrypt", "~> 3.1.7"
 gem "tailwindcss-rails"
 gem "view_component"
 gem "rails_icons"
+gem "lookbook", "~> 2.3", require: false
 
 gem "tzinfo-data", platforms: %i[ windows jruby ]
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -94,6 +94,9 @@ GEM
     concurrent-ruby (1.3.6)
     connection_pool (3.0.2)
     crass (1.0.6)
+    css_parser (3.0.0)
+      addressable
+      ssrf_filter (~> 1.5)
     date (3.5.1)
     debug (1.11.1)
       irb (~> 1.10)
@@ -107,6 +110,8 @@ GEM
     erubi (1.13.1)
     globalid (1.3.0)
       activesupport (>= 6.1)
+    htmlbeautifier (1.4.3)
+    htmlentities (4.3.4)
     i18n (1.14.8)
       concurrent-ruby (~> 1.0)
     icons (0.8.1)
@@ -128,6 +133,18 @@ GEM
     loofah (2.25.1)
       crass (~> 1.0.2)
       nokogiri (>= 1.12.0)
+    lookbook (2.3.14)
+      activemodel
+      css_parser
+      htmlbeautifier (~> 1.3)
+      htmlentities (~> 4.3.4)
+      marcel (~> 1.0)
+      railties (>= 5.0)
+      redcarpet (~> 3.5)
+      rouge (>= 3.26, < 5.0)
+      view_component (>= 2.0)
+      yard (~> 0.9)
+      zeitwerk (~> 2.5)
     mail (2.9.0)
       logger
       mini_mime (>= 0.1.1)
@@ -239,10 +256,12 @@ GEM
       erb
       psych (>= 4.0.0)
       tsort
+    redcarpet (3.6.1)
     regexp_parser (2.12.0)
     reline (0.6.3)
       io-console (~> 0.5)
     rexml (3.4.4)
+    rouge (4.7.0)
     rubocop (1.88.2)
       json (~> 2.3)
       language_server-protocol (~> 3.17.0.2)
@@ -288,6 +307,7 @@ GEM
     sqlite3 (2.9.3-x86_64-darwin)
     sqlite3 (2.9.3-x86_64-linux-gnu)
     sqlite3 (2.9.3-x86_64-linux-musl)
+    ssrf_filter (1.5.0)
     stimulus-rails (1.3.4)
       railties (>= 6.0.0)
     stringio (3.2.0)
@@ -322,6 +342,7 @@ GEM
     websocket-extensions (0.1.5)
     xpath (3.2.0)
       nokogiri (~> 1.8)
+    yard (0.9.45)
     zeitwerk (2.7.5)
 
 PLATFORMS
@@ -340,6 +361,7 @@ DEPENDENCIES
   debug
   dotenv-rails
   importmap-rails (~> 2.2)
+  lookbook (~> 2.3)
   pg (~> 1.6)
   propshaft
   puma (>= 5.0)
@@ -376,6 +398,7 @@ CHECKSUMS
   concurrent-ruby (1.3.6) sha256=6b56837e1e7e5292f9864f34b69c5a2cbc75c0cf5338f1ce9903d10fa762d5ab
   connection_pool (3.0.2) sha256=33fff5ba71a12d2aa26cb72b1db8bba2a1a01823559fb01d29eb74c286e62e0a
   crass (1.0.6) sha256=dc516022a56e7b3b156099abc81b6d2b08ea1ed12676ac7a5657617f012bd45d
+  css_parser (3.0.0) sha256=eaf0e9283fd581d06e815235ceef4f0910c0b394c606355dbc69f93e84443885
   date (3.5.1) sha256=750d06384d7b9c15d562c76291407d89e368dda4d4fff957eb94962d325a0dc0
   debug (1.11.1) sha256=2e0b0ac6119f2207a6f8ac7d4a73ca8eb4e440f64da0a3136c30343146e952b6
   dotenv (3.2.0) sha256=e375b83121ea7ca4ce20f214740076129ab8514cd81378161f11c03853fe619d
@@ -384,6 +407,8 @@ CHECKSUMS
   erb (6.0.3) sha256=e43685a8a0a0ea6a924871b2162e8953ef73147ce46b75b36d1f6774fd286e91
   erubi (1.13.1) sha256=a082103b0885dbc5ecf1172fede897f9ebdb745a4b97a5e8dc63953db1ee4ad9
   globalid (1.3.0) sha256=05c639ad6eb4594522a0b07983022f04aa7254626ab69445a0e493aa3786ff11
+  htmlbeautifier (1.4.3) sha256=b43d08f7e2aa6ae1b5a6f0607b4ed8954c8d4a8e85fd2336f975dda1e4db385b
+  htmlentities (4.3.4) sha256=125a73c6c9f2d1b62100b7c3c401e3624441b663762afa7fe428476435a673da
   i18n (1.14.8) sha256=285778639134865c5e0f6269e0b818256017e8cde89993fdfcbfb64d088824a5
   icons (0.8.1) sha256=fd88161f51ba5a867b45ced2a60a567cf5279443c9e6b69b12a09f381378f4e8
   importmap-rails (2.2.3) sha256=7101be2a4dc97cf1558fb8f573a718404c5f6bcfe94f304bf1f39e444feeb16a
@@ -394,6 +419,7 @@ CHECKSUMS
   lint_roller (1.1.0) sha256=2c0c845b632a7d172cb849cc90c1bce937a28c5c8ccccb50dfd46a485003cc87
   logger (1.7.0) sha256=196edec7cc44b66cfb40f9755ce11b392f21f7967696af15d274dde7edff0203
   loofah (2.25.1) sha256=d436c73dbd0c1147b16c4a41db097942d217303e1f7728704b37e4df9f6d2e04
+  lookbook (2.3.14) sha256=c11a693bde9915b553c4463440ad5e750829f90bff08abdb6b8610373864cd7c
   mail (2.9.0) sha256=6fa6673ecd71c60c2d996260f9ee3dd387d4673b8169b502134659ece6d34941
   marcel (1.1.0) sha256=fdcfcfa33cc52e93c4308d40e4090a5d4ea279e160a7f6af988260fa970e0bee
   matrix (0.4.3) sha256=a0d5ab7ddcc1973ff690ab361b67f359acbb16958d1dc072b8b956a286564c5b
@@ -441,9 +467,11 @@ CHECKSUMS
   rainbow (3.1.1) sha256=039491aa3a89f42efa1d6dec2fc4e62ede96eb6acd95e52f1ad581182b79bc6a
   rake (13.4.2) sha256=cb825b2bd5f1f8e91ca37bddb4b9aaf345551b4731da62949be002fa89283701
   rdoc (7.2.0) sha256=8650f76cd4009c3b54955eb5d7e3a075c60a57276766ebf36f9085e8c9f23192
+  redcarpet (3.6.1) sha256=d444910e6aa55480c6bcdc0cdb057626e8a32c054c29e793fa642ba2f155f445
   regexp_parser (2.12.0) sha256=35a916a1d63190ab5c9009457136ae5f3c0c7512d60291d0d1378ba18ce08ebb
   reline (0.6.3) sha256=1198b04973565b36ec0f11542ab3f5cfeeec34823f4e54cebde90968092b1835
   rexml (3.4.4) sha256=19e0a2c3425dfbf2d4fc1189747bdb2f849b6c5e74180401b15734bc97b5d142
+  rouge (4.7.0) sha256=dba5896715c0325c362e895460a6d350803dbf6427454f49a47500f3193ea739
   rubocop (1.88.2) sha256=8def251c90cd955feb4daa3edc0ab56893250c4ce90ef81e6c80c03f9a939bbf
   rubocop-ast (1.50.0) sha256=b9ca88300da0803ee222ad20cdb30494c0a784eed06fdc35d254b06d662788db
   rubocop-performance (1.26.1) sha256=cd19b936ff196df85829d264b522fd4f98b6c89ad271fa52744a8c11b8f71834
@@ -461,6 +489,7 @@ CHECKSUMS
   sqlite3 (2.9.3-x86_64-darwin) sha256=087e7cc4efc73d83e76354f028c4d1dc14552a05acc74f60e77a55f1bee6ef22
   sqlite3 (2.9.3-x86_64-linux-gnu) sha256=85200a10c6cf5c60085fcca411a3168c5fba8fda3e2b1b0109ec277d7c226d46
   sqlite3 (2.9.3-x86_64-linux-musl) sha256=b6d0437046d9180335dea1aa0592802e65c4f7b57409d63f14408211bf28536b
+  ssrf_filter (1.5.0) sha256=e03dcdb9d1730d7f6710532a606b3543df2a448a0293ce04a2d995523c5a97f6
   stimulus-rails (1.3.4) sha256=765676ffa1f33af64ce026d26b48e8ffb2e0b94e0f50e9119e11d6107d67cb06
   stringio (3.2.0) sha256=c37cb2e58b4ffbd33fe5cd948c05934af997b36e0b6ca6fdf43afa234cf222e1
   tailwindcss-rails (4.4.0) sha256=efa2961351a52acebe616e645a81a30bb4f27fde46cc06ce7688d1cd1131e916
@@ -484,6 +513,7 @@ CHECKSUMS
   websocket-driver (0.8.0) sha256=ed0dba4b943c22f17f9a734817e808bc84cdce6a7e22045f5315aa57676d4962
   websocket-extensions (0.1.5) sha256=1c6ba63092cda343eb53fc657110c71c754c56484aad42578495227d717a8241
   xpath (3.2.0) sha256=6dfda79d91bb3b949b947ecc5919f042ef2f399b904013eb3ef6d20dd3a4082e
+  yard (0.9.45) sha256=52e211493f7cb8a3ebf7e104a25a1e73937a3103092545d34cb88fafebb3dc51
   zeitwerk (2.7.5) sha256=d8da92128c09ea6ec62c949011b00ed4a20242b255293dd66bf41545398f73dd
 
 BUNDLED WITH

--- a/README.md
+++ b/README.md
@@ -102,6 +102,8 @@ stay as partials until they have a genuine reuse case.
 
 Previews live in `test/components/previews`. They document the supported UI
 and site compositions without turning visual details into test contracts.
+Run the app and open `/lookbook` to browse them. Lookbook is also available on
+PR preview deployments and remains unmounted on production.
 
 ## Checks
 

--- a/app/views/layouts/_preview_banner.html.erb
+++ b/app/views/layouts/_preview_banner.html.erb
@@ -5,9 +5,15 @@
       <%= link_to "Return to griffithict.club", site_meta[:url] %>
       ·
       <%= link_to "View PR ##{ENV.fetch("PREVIEW_PR_NUMBER")}", "#{site_socials[:github]}pull/#{ENV.fetch("PREVIEW_PR_NUMBER")}", target: "_blank", rel: "noopener" %>
+      ·
+      <%= link_to "View components", lookbook_path %>
     </div>
   <% else %>
     <div>You are on a development branch. Information may be outdated or incorrect.</div>
-    <div><%= link_to "Return to griffithict.club", site_meta[:url] %></div>
+    <div>
+      <%= link_to "Return to griffithict.club", site_meta[:url] %>
+      ·
+      <%= link_to "View components", lookbook_path %>
+    </div>
   <% end %>
 </aside>

--- a/config/application.rb
+++ b/config/application.rb
@@ -17,6 +17,8 @@ require "rails/test_unit/railtie"
 # Require the gems listed in Gemfile, including any gems
 # you've limited to :test, :development, or :production.
 Bundler.require(*Rails.groups)
+require "lookbook" if Rails.env.development? || ENV["PREVIEW_PR_NUMBER"].present?
+Lookbook.config.preview_paths = [] if defined?(Lookbook)
 
 module GriffithIctWeb
   class Application < Rails::Application
@@ -27,6 +29,9 @@ module GriffithIctWeb
     # not contain `.rb` files, or that should not be reloaded or eager loaded.
     # Common ones are `templates`, `generators`, or `middleware`, for example.
     config.autoload_lib(ignore: %w[assets tasks])
+    if Rails.env.development? || ENV["PREVIEW_PR_NUMBER"].present?
+      config.eager_load_paths << Rails.root.join("test/components/previews").to_s
+    end
 
     # Configuration for the application, engines, and railties goes here.
     #

--- a/config/initializers/lookbook.rb
+++ b/config/initializers/lookbook.rb
@@ -1,0 +1,8 @@
+if defined?(Lookbook)
+  Lookbook.configure do |config|
+    config.project_name = "Griffith ICT Club"
+    config.preview_collection_label = "Components"
+    config.preview_layout = "component_preview"
+    config.live_updates = false
+  end
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,4 +1,5 @@
 Rails.application.routes.draw do
+  mount Lookbook::Engine, at: "/lookbook", as: :lookbook if defined?(Lookbook)
   mount RailsIcons::Engine, at: "/rails_icons" if Rails.env.development?
 
   resource :session, only: %i[new create destroy]

--- a/test/components/previews/site/flash_component_preview.rb
+++ b/test/components/previews/site/flash_component_preview.rb
@@ -1,7 +1,7 @@
 module Site
   class FlashComponentPreview < ViewComponent::Preview
     def messages
-      render FlashComponent.new(flash: { notice: "Changes saved.", alert: "Something went wrong." })
+      render Site::FlashComponent.new(flash: { notice: "Changes saved.", alert: "Something went wrong." })
     end
   end
 end

--- a/test/components/previews/site/footer_component_preview.rb
+++ b/test/components/previews/site/footer_component_preview.rb
@@ -1,7 +1,7 @@
 module Site
   class FooterComponentPreview < ViewComponent::Preview
     def default
-      render FooterComponent.new
+      render Site::FooterComponent.new
     end
   end
 end

--- a/test/components/previews/site/membership_dialog_component_preview.rb
+++ b/test/components/previews/site/membership_dialog_component_preview.rb
@@ -1,5 +1,6 @@
 module Site
   class MembershipDialogComponentPreview < ViewComponent::Preview
+    # Membership composes Dialog, Steps, and Button without constructing content in JavaScript.
     def default
       render_with_template
     end

--- a/test/components/previews/site/navbar_component_preview.rb
+++ b/test/components/previews/site/navbar_component_preview.rb
@@ -1,7 +1,7 @@
 module Site
   class NavbarComponentPreview < ViewComponent::Preview
     def default
-      render NavbarComponent.new
+      render Site::NavbarComponent.new
     end
   end
 end

--- a/test/components/previews/ui/alert_component_preview.rb
+++ b/test/components/previews/ui/alert_component_preview.rb
@@ -1,11 +1,19 @@
 module Ui
   class AlertComponentPreview < ViewComponent::Preview
+    # Alerts communicate a page-level result or important neutral information.
+    # @param message text
+    # @param variant select { choices: [notice, alert, neutral] }
+    # @param dismissible toggle
+    def playground(message: "Your changes were saved.", variant: "notice", dismissible: true)
+      render Ui::AlertComponent.new(variant: variant.to_sym, dismissible: dismissible).with_content(message)
+    end
+
     def variants
       render_with_template
     end
 
     def dismissible
-      render AlertComponent.new(variant: :notice, dismissible: true).with_content("Your changes were saved.")
+      render Ui::AlertComponent.new(variant: :notice, dismissible: true).with_content("Your changes were saved.")
     end
   end
 end

--- a/test/components/previews/ui/badge_component_preview.rb
+++ b/test/components/previews/ui/badge_component_preview.rb
@@ -1,5 +1,13 @@
 module Ui
   class BadgeComponentPreview < ViewComponent::Preview
+    # Badges label compact status or category information; they are not interactive.
+    # @param label text
+    # @param variant select { choices: [brand, dark, success, neutral] }
+    # @param size select { choices: [small, medium] }
+    def playground(label: "Upcoming", variant: "brand", size: "medium")
+      render Ui::BadgeComponent.new(variant: variant.to_sym, size: size.to_sym).with_content(label)
+    end
+
     def variants
       render_with_template
     end

--- a/test/components/previews/ui/button_component_preview.rb
+++ b/test/components/previews/ui/button_component_preview.rb
@@ -1,7 +1,20 @@
 module Ui
   class ButtonComponentPreview < ViewComponent::Preview
+    # Use buttons for actions and links styled as actions. Keep labels short and specific.
+    # @param label text
+    # @param variant select { choices: [primary, secondary, danger, quiet] }
+    # @param size select { choices: [small, medium] }
+    # @param disabled toggle
+    def playground(label: "Save changes", variant: "primary", size: "medium", disabled: false)
+      render Ui::ButtonComponent.new(
+        variant: variant.to_sym,
+        size: size.to_sym,
+        disabled: disabled
+      ).with_content(label)
+    end
+
     def primary
-      render ButtonComponent.new.with_content("Primary action")
+      render Ui::ButtonComponent.new.with_content("Primary action")
     end
 
     def variants
@@ -13,7 +26,7 @@ module Ui
     end
 
     def disabled
-      render ButtonComponent.new(disabled: true).with_content("Unavailable")
+      render Ui::ButtonComponent.new(disabled: true).with_content("Unavailable")
     end
   end
 end

--- a/test/components/previews/ui/card_component_preview.rb
+++ b/test/components/previews/ui/card_component_preview.rb
@@ -1,5 +1,20 @@
 module Ui
   class CardComponentPreview < ViewComponent::Preview
+    # Cards group related content. Turn on interactive only when the whole card has an action.
+    # @param content text
+    # @param tone select { choices: [default, cream, red, dark] }
+    # @param padding select { choices: [none, small, medium, large] }
+    # @param shadow select { choices: [none, black, red] }
+    # @param interactive toggle
+    def playground(content: "A concise block of related content.", tone: "default", padding: "medium", shadow: "none", interactive: false)
+      render Ui::CardComponent.new(
+        tone: tone.to_sym,
+        padding: padding.to_sym,
+        shadow: shadow.to_sym,
+        interactive: interactive
+      ).with_content(content)
+    end
+
     def tones
       render_with_template
     end

--- a/test/components/previews/ui/dialog_component_preview.rb
+++ b/test/components/previews/ui/dialog_component_preview.rb
@@ -1,5 +1,13 @@
 module Ui
   class DialogComponentPreview < ViewComponent::Preview
+    # Dialogs hold focused tasks that should interrupt the current page without navigating away.
+    # @param title text
+    # @param size select { choices: [small, medium, large] }
+    def playground(title: "Confirm action", size: "medium")
+      render Ui::DialogComponent.new(id: "playground-dialog", title: title, size: size.to_sym, open: true)
+        .with_content("Keep dialog content focused and provide a clear next action.")
+    end
+
     def default
       render_with_template
     end

--- a/test/components/previews/ui/steps_component_preview.rb
+++ b/test/components/previews/ui/steps_component_preview.rb
@@ -1,11 +1,17 @@
 module Ui
   class StepsComponentPreview < ViewComponent::Preview
+    # Steps communicate progress through a short, linear task such as a multi-step dialog.
+    # @param current select { choices: [1, 2] }
+    def playground(current: "1")
+      render Ui::StepsComponent.new(labels: [ "Join Discord", "Register" ], current: current.to_i)
+    end
+
     def first_step
-      render StepsComponent.new(labels: [ "Join Discord", "Register" ])
+      render Ui::StepsComponent.new(labels: [ "Join Discord", "Register" ])
     end
 
     def second_step
-      render StepsComponent.new(labels: [ "Join Discord", "Register" ], current: 2)
+      render Ui::StepsComponent.new(labels: [ "Join Discord", "Register" ], current: 2)
     end
   end
 end


### PR DESCRIPTION
## Summary

- adds Lookbook 2.3 as a development and PR-preview-only sidecar
- automatically discovers the native ViewComponent previews from PR 1 and organizes them under Ui and Site
- adds playground controls and concise usage notes, including the multi-step progress pattern
- loads the production Tailwind bundle, fonts, icons, importmap, and Stimulus behavior in component previews
- links Lookbook from the PR-preview banner and keeps live reload dependencies out

## Mounting

- development: mounted at /lookbook
- PR previews: mounted when PREVIEW_PR_NUMBER is present
- production: not loaded or mounted

## Verification

- Lookbook UI and component previews exercised in the browser
- production route check returns false without PREVIEW_PR_NUMBER and true with it
- bin/rails test: 33 runs, 141 assertions, 0 failures
- bin/rubocop
- bin/rails zeitwerk:check
- bin/rails assets:precompile

This PR is intentionally stacked on PR #74 and should merge after it.